### PR TITLE
[R4R] fix(committer): remove failed tx from mempool

### DIFF
--- a/service/cronjob/committer/internal/logic/committerTask.go
+++ b/service/cronjob/committer/internal/logic/committerTask.go
@@ -127,6 +127,7 @@ func CommitterTask(ctx *svc.ServiceContext, lastCommitTimeStamp *time.Time,
 		// compute block commitment
 		createdAt := time.Now().UnixMilli()
 
+	OUTER:
 		for j := 0; j < MaxTxsAmountPerBlock; j++ {
 			// if not full block, just break
 			if i*MaxTxsAmountPerBlock+j >= nTxs {
@@ -317,7 +318,7 @@ func CommitterTask(ctx *svc.ServiceContext, lastCommitTimeStamp *time.Time,
 						mempoolTx.Status = mempool.FailTxStatus
 						mempoolTx.L2BlockHeight = currentBlockHeight
 						pendingDeleteMempoolTxs = append(pendingDeleteMempoolTxs, mempoolTx)
-						continue
+						continue OUTER
 					}
 					accountMap[mempoolTxDetail.AccountIndex].AssetInfo[mempoolTxDetail.AssetId] = nAccountAsset
 					// update account state tree


### PR DESCRIPTION
### Description

For now, though the mempool tx is marked as failed if balance is not enough, it will finally be marked as successful at the end.

```go
	// check balance is valid
	if nAccountAsset.Balance.Cmp(util.ZeroBigInt) < 0 {
		// mark this transaction as invalid transaction
		mempoolTx.Status = mempool.FailTxStatus
		mempoolTx.L2BlockHeight = currentBlockHeight
		pendingDeleteMempoolTxs = append(pendingDeleteMempoolTxs, mempoolTx)
		continue
	}
```

at the end:
```go
	// update mempool tx info
	mempoolTx.L2BlockHeight = currentBlockHeight
	mempoolTx.Status = mempool.SuccessTxStatus
```

So we need to continue the outer loop to avoid marking the failed tx as failed.

### Rationale


### Example


### Changes

Notable changes:
* fix the issue including failed mempool txs in block
