### PR TITLE
globalRPC: fix incorrect create collection check

### DIFF
--- a/common/model/nft/nftCollection.go
+++ b/common/model/nft/nftCollection.go
@@ -31,7 +31,7 @@ type (
 	L2NftCollectionModel interface {
 		CreateL2NftCollectionTable() error
 		DropL2NftCollectionTable() error
-		IfCollectionExistsByCollectionId(collectionId int64) (bool, error)
+		IfCollectionExistsByCollectionId(accountIndex, collectionId int64) (bool, error)
 	}
 	defaultL2NftCollectionModel struct {
 		sqlc.CachedConn
@@ -80,9 +80,9 @@ func (m *defaultL2NftCollectionModel) CreateL2NftCollectionTable() error {
 func (m *defaultL2NftCollectionModel) DropL2NftCollectionTable() error {
 	return m.DB.Migrator().DropTable(m.table)
 }
-func (m *defaultL2NftCollectionModel) IfCollectionExistsByCollectionId(collectionId int64) (bool, error) {
+func (m *defaultL2NftCollectionModel) IfCollectionExistsByCollectionId(accountIndex, collectionId int64) (bool, error) {
 	var res int64
-	dbTx := m.DB.Table(m.table).Where("collection_id = ? and deleted_at is NULL", collectionId).Count(&res)
+	dbTx := m.DB.Table(m.table).Where("account_index = ? and collection_id = ? and deleted_at is NULL", accountIndex, collectionId).Count(&res)
 
 	if dbTx.Error != nil {
 		logx.Error("[collection.IfCollectionExistsByCollectionId] %s", dbTx.Error)

--- a/service/rpc/globalRPC/internal/logic/sendcreatecollectiontxlogic.go
+++ b/service/rpc/globalRPC/internal/logic/sendcreatecollectiontxlogic.go
@@ -127,7 +127,7 @@ func createMempoolTxForCreateCollection(
 	svcCtx *svc.ServiceContext,
 ) (err error) {
 	// check collectionId exist
-	exist, err := svcCtx.CollectionModel.IfCollectionExistsByCollectionId(nftCollectionInfo.CollectionId)
+	exist, err := svcCtx.CollectionModel.IfCollectionExistsByCollectionId(nftCollectionInfo.AccountIndex, nftCollectionInfo.CollectionId)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description

The existing check of duplicated collection creation is not correct. Previous tests often use the same account, and this bug is not identified.

### Rationale

Bug fix - duplicated collection creation check is not correct.

### Example

NA

### Changes

Notable changes:
* update check