### PR TITLE
model: remove unique nft index restraint

### DIFF
--- a/common/model/nft/nftWithdrawHistory.go
+++ b/common/model/nft/nftWithdrawHistory.go
@@ -37,7 +37,7 @@ type (
 
 	L2NftWithdrawHistory struct {
 		gorm.Model
-		NftIndex            int64 `gorm:"uniqueIndex"`
+		NftIndex            int64
 		CreatorAccountIndex int64
 		OwnerAccountIndex   int64
 		NftContentHash      string


### PR DESCRIPTION
### Description

Remove unique nft index constraint.

For `FullExitNft`, there may be multiple records for the same nft index.

### Changes

Notable changes:
* remove index constraint for nft index
* ...