### PR TITLE
refactor: make logs info more concentrate and reduce useless logs

### DIFF
--- a/dao/account/account.go
+++ b/dao/account/account.go
@@ -18,9 +18,6 @@
 package account
 
 import (
-	"fmt"
-
-	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stores/cache"
 	"github.com/zeromicro/go-zero/core/stores/sqlc"
 	"github.com/zeromicro/go-zero/core/stores/sqlx"
@@ -101,7 +98,6 @@ func (m *defaultAccountModel) DropAccountTable() error {
 func (m *defaultAccountModel) GetAccountByIndex(accountIndex int64) (account *Account, err error) {
 	dbTx := m.DB.Table(m.table).Where("account_index = ?", accountIndex).Find(&account)
 	if dbTx.Error != nil {
-		logx.Errorf("get account by index error, err: %s", dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound
@@ -112,12 +108,8 @@ func (m *defaultAccountModel) GetAccountByIndex(accountIndex int64) (account *Ac
 func (m *defaultAccountModel) GetAccountByPk(pk string) (account *Account, err error) {
 	dbTx := m.DB.Table(m.table).Where("public_key = ?", pk).Find(&account)
 	if dbTx.Error != nil {
-		err := fmt.Sprintf("[account.GetAccountByPk] %s", dbTx.Error.Error())
-		logx.Error(err)
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
-		err := fmt.Sprintf("[account.GetAccountByPk] %s", types.DbErrNotFound)
-		logx.Error(err)
 		return nil, types.DbErrNotFound
 	}
 	return account, nil
@@ -126,7 +118,6 @@ func (m *defaultAccountModel) GetAccountByPk(pk string) (account *Account, err e
 func (m *defaultAccountModel) GetAccountByName(accountName string) (account *Account, err error) {
 	dbTx := m.DB.Table(m.table).Where("account_name = ?", accountName).Find(&account)
 	if dbTx.Error != nil {
-		logx.Errorf("get account by account name error, err: %s", dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound
@@ -137,7 +128,6 @@ func (m *defaultAccountModel) GetAccountByName(accountName string) (account *Acc
 func (m *defaultAccountModel) GetAccountByNameHash(accountNameHash string) (account *Account, err error) {
 	dbTx := m.DB.Table(m.table).Where("account_name_hash = ?", accountNameHash).Find(&account)
 	if dbTx.Error != nil {
-		logx.Errorf("get account by account name hash error, err: %s", dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound
@@ -148,7 +138,6 @@ func (m *defaultAccountModel) GetAccountByNameHash(accountNameHash string) (acco
 func (m *defaultAccountModel) GetAccountsList(limit int, offset int64) (accounts []*Account, err error) {
 	dbTx := m.DB.Table(m.table).Limit(limit).Offset(int(offset)).Order("account_index desc").Find(&accounts)
 	if dbTx.Error != nil {
-		logx.Errorf("get account list error, err: %s", dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound
@@ -159,7 +148,6 @@ func (m *defaultAccountModel) GetAccountsList(limit int, offset int64) (accounts
 func (m *defaultAccountModel) GetAccountsTotalCount() (count int64, err error) {
 	dbTx := m.DB.Table(m.table).Where("deleted_at is NULL").Count(&count)
 	if dbTx.Error != nil {
-		logx.Errorf("get account count error, error: %s", dbTx.Error.Error())
 		return 0, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return 0, nil
@@ -170,7 +158,6 @@ func (m *defaultAccountModel) GetAccountsTotalCount() (count int64, err error) {
 func (m *defaultAccountModel) GetConfirmedAccountByIndex(accountIndex int64) (account *Account, err error) {
 	dbTx := m.DB.Table(m.table).Where("account_index = ? and status = ?", accountIndex, AccountStatusConfirmed).Find(&account)
 	if dbTx.Error != nil {
-		logx.Errorf("get confirmed account by account index error, err: %s", dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound

--- a/dao/account/account_history.go
+++ b/dao/account/account_history.go
@@ -19,7 +19,6 @@ package account
 import (
 	"errors"
 
-	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stores/cache"
 	"github.com/zeromicro/go-zero/core/stores/sqlc"
 	"github.com/zeromicro/go-zero/core/stores/sqlx"
@@ -80,7 +79,6 @@ func (m *defaultAccountHistoryModel) DropAccountHistoryTable() error {
 func (m *defaultAccountHistoryModel) CreateNewAccount(nAccount *AccountHistory) (err error) {
 	dbTx := m.DB.Table(m.table).Create(&nAccount)
 	if dbTx.Error != nil {
-		logx.Errorf("create new account error, err: %s", dbTx.Error.Error())
 		return types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return errors.New("create new account no rows affected")
@@ -99,7 +97,6 @@ func (m *defaultAccountHistoryModel) GetValidAccounts(height int64, limit int, o
 		Order("account_index")
 
 	if dbTx.Find(&accounts).Error != nil {
-		logx.Errorf("[GetValidAccounts] unable to get related accounts: %s", dbTx.Error.Error())
 		return 0, nil, types.DbErrSqlOperation
 	}
 	return dbTx.RowsAffected, accounts, nil
@@ -114,7 +111,6 @@ func (m *defaultAccountHistoryModel) GetValidAccountCount(height int64) (count i
 		Where("NOT EXISTS (?) AND l2_block_height <= ? AND l2_block_height != -1", subQuery, height)
 
 	if dbTx.Count(&count).Error != nil {
-		logx.Errorf("[GetValidAccountCount] unable to get related accounts: %s", dbTx.Error.Error())
 		return 0, types.DbErrSqlOperation
 	}
 	return count, nil

--- a/dao/asset/asset.go
+++ b/dao/asset/asset.go
@@ -18,7 +18,6 @@
 package asset
 
 import (
-	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stores/cache"
 	"github.com/zeromicro/go-zero/core/stores/sqlc"
 	"github.com/zeromicro/go-zero/core/stores/sqlx"
@@ -91,7 +90,6 @@ func (m *defaultAssetModel) DropAssetTable() error {
 func (m *defaultAssetModel) GetAssetsTotalCount() (count int64, err error) {
 	dbTx := m.DB.Table(m.table).Where("deleted_at is NULL").Count(&count)
 	if dbTx.Error != nil {
-		logx.Errorf("get total asset count error, err: %s", dbTx.Error.Error())
 		return 0, dbTx.Error
 	} else if dbTx.RowsAffected == 0 {
 		return 0, nil
@@ -102,7 +100,6 @@ func (m *defaultAssetModel) GetAssetsTotalCount() (count int64, err error) {
 func (m *defaultAssetModel) GetAssetsList(limit int64, offset int64) (res []*Asset, err error) {
 	dbTx := m.DB.Table(m.table).Limit(int(limit)).Offset(int(offset)).Order("id asc").Find(&res)
 	if dbTx.Error != nil {
-		logx.Errorf("get assets error, err: %s", dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	}
 	if dbTx.RowsAffected == 0 {
@@ -114,7 +111,6 @@ func (m *defaultAssetModel) GetAssetsList(limit int64, offset int64) (res []*Ass
 func (m *defaultAssetModel) CreateAssetsInBatch(l2Assets []*Asset) (rowsAffected int64, err error) {
 	dbTx := m.DB.Table(m.table).CreateInBatches(l2Assets, len(l2Assets))
 	if dbTx.Error != nil {
-		logx.Errorf("create assets error, err: %s", dbTx.Error.Error())
 		return 0, types.DbErrSqlOperation
 	}
 	if dbTx.RowsAffected == 0 {
@@ -126,7 +122,6 @@ func (m *defaultAssetModel) CreateAssetsInBatch(l2Assets []*Asset) (rowsAffected
 func (m *defaultAssetModel) GetAssetById(assetId int64) (res *Asset, err error) {
 	dbTx := m.DB.Table(m.table).Where("asset_id = ?", assetId).Find(&res)
 	if dbTx.Error != nil {
-		logx.Errorf("get asset error, err: %s", dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	}
 	if dbTx.RowsAffected == 0 {
@@ -138,7 +133,6 @@ func (m *defaultAssetModel) GetAssetById(assetId int64) (res *Asset, err error) 
 func (m *defaultAssetModel) GetAssetBySymbol(symbol string) (res *Asset, err error) {
 	dbTx := m.DB.Table(m.table).Where("asset_symbol = ?", symbol).Find(&res)
 	if dbTx.Error != nil {
-		logx.Errorf("get asset error, err: %s", dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	}
 	if dbTx.RowsAffected == 0 {
@@ -150,7 +144,6 @@ func (m *defaultAssetModel) GetAssetBySymbol(symbol string) (res *Asset, err err
 func (m *defaultAssetModel) GetAssetByAddress(address string) (asset *Asset, err error) {
 	dbTx := m.DB.Table(m.table).Where("asset_address = ?", address).Find(&asset)
 	if dbTx.Error != nil {
-		logx.Errorf("fail to get asset by address: %s, error: %s", address, dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound
@@ -161,7 +154,6 @@ func (m *defaultAssetModel) GetAssetByAddress(address string) (asset *Asset, err
 func (m *defaultAssetModel) GetGasAssets() (assets []*Asset, err error) {
 	dbTx := m.DB.Table(m.table).Where("is_gas_asset = ?", IsGasAsset).Find(&assets)
 	if dbTx.Error != nil {
-		logx.Errorf("fail to get gas assets, error: %s", dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound
@@ -172,7 +164,6 @@ func (m *defaultAssetModel) GetGasAssets() (assets []*Asset, err error) {
 func (m *defaultAssetModel) GetMaxId() (max int64, err error) {
 	dbTx := m.DB.Table(m.table).Select("id").Order("id desc").Limit(1).Find(&max)
 	if dbTx.Error != nil {
-		logx.Errorf("get max asset id error, err: %s", dbTx.Error.Error())
 		return 0, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return 0, types.DbErrNotFound

--- a/dao/blockwitness/block_witness.go
+++ b/dao/blockwitness/block_witness.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stores/cache"
 	"github.com/zeromicro/go-zero/core/stores/sqlc"
 	"github.com/zeromicro/go-zero/core/stores/sqlx"
@@ -80,7 +79,6 @@ func (m *defaultBlockWitnessModel) GetLatestBlockWitnessHeight() (blockNumber in
 	var row *BlockWitness
 	dbTx := m.DB.Table(m.table).Order("height desc").Limit(1).Find(&row)
 	if dbTx.Error != nil {
-		logx.Errorf("unable to get latest witness: %s", dbTx.Error.Error())
 		return 0, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return 0, types.DbErrNotFound
@@ -93,7 +91,6 @@ func (m *defaultBlockWitnessModel) GetBlockWitnessByMode(mode int64) (witness *B
 	case prove.CooMode:
 		dbTx := m.DB.Table(m.table).Where("status = ?", StatusPublished).Order("height asc").Limit(1).Find(&witness)
 		if dbTx.Error != nil {
-			logx.Errorf("unable to get witness: %s", dbTx.Error.Error())
 			return nil, types.DbErrSqlOperation
 		} else if dbTx.RowsAffected == 0 {
 			return nil, types.DbErrNotFound
@@ -102,7 +99,6 @@ func (m *defaultBlockWitnessModel) GetBlockWitnessByMode(mode int64) (witness *B
 	case prove.ComMode:
 		dbTx := m.DB.Table(m.table).Where("status <= ?", StatusReceived).Order("height asc").Limit(1).Find(&witness)
 		if dbTx.Error != nil {
-			logx.Errorf("unable to get witness: %s", dbTx.Error.Error())
 			return nil, types.DbErrSqlOperation
 		} else if dbTx.RowsAffected == 0 {
 			return nil, types.DbErrNotFound
@@ -116,7 +112,6 @@ func (m *defaultBlockWitnessModel) GetBlockWitnessByMode(mode int64) (witness *B
 func (m *defaultBlockWitnessModel) GetBlockWitnessByNumber(height int64) (witness *BlockWitness, err error) {
 	dbTx := m.DB.Table(m.table).Where("height = ?", height).Limit(1).Find(&witness)
 	if dbTx.Error != nil {
-		logx.Errorf("unable to get witness: %s", dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound
@@ -128,14 +123,12 @@ func (m *defaultBlockWitnessModel) CreateBlockWitness(witness *BlockWitness) err
 	if witness.Height > 1 {
 		_, err := m.GetBlockWitnessByNumber(witness.Height - 1)
 		if err != nil {
-			logx.Infof("get witness error, err: %s", err.Error())
 			return fmt.Errorf("previous witness does not exist")
 		}
 	}
 
 	dbTx := m.DB.Table(m.table).Create(witness)
 	if dbTx.Error != nil {
-		logx.Errorf("create witness error, err: %s", dbTx.Error.Error())
 		return types.DbErrSqlOperation
 	}
 	return nil
@@ -146,7 +139,6 @@ func (m *defaultBlockWitnessModel) UpdateBlockWitnessStatus(witness *BlockWitnes
 	witness.UpdatedAt = time.Now()
 	dbTx := m.DB.Table(m.table).Save(witness)
 	if dbTx.Error != nil {
-		logx.Errorf("update witness status error: %s", dbTx.Error.Error())
 		return types.DbErrSqlOperation
 	}
 	return nil

--- a/dao/compressedblock/compressed_block.go
+++ b/dao/compressedblock/compressed_block.go
@@ -18,7 +18,6 @@
 package compressedblock
 
 import (
-	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stores/cache"
 	"github.com/zeromicro/go-zero/core/stores/sqlc"
 	"github.com/zeromicro/go-zero/core/stores/sqlx"
@@ -78,7 +77,6 @@ func (m *defaultCompressedBlockModel) DropCompressedBlockTable() error {
 func (m *defaultCompressedBlockModel) GetCompressedBlockBetween(start, end int64) (blocksForCommit []*CompressedBlock, err error) {
 	dbTx := m.DB.Table(m.table).Where("block_height >= ? AND block_height <= ?", start, end).Find(&blocksForCommit)
 	if dbTx.Error != nil {
-		logx.Errorf("unable to get block for commit between: %s", dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound

--- a/dao/l1syncedblock/l1_synced_block.go
+++ b/dao/l1syncedblock/l1_synced_block.go
@@ -18,10 +18,8 @@
 package l1syncedblock
 
 import (
-	"encoding/json"
 	"errors"
 
-	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stores/cache"
 	"github.com/zeromicro/go-zero/core/stores/sqlc"
 	"github.com/zeromicro/go-zero/core/stores/sqlx"
@@ -134,16 +132,12 @@ func (m *defaultL1EventModel) CreateGenericBlock(
 					Select("*").
 					Updates(&pendingUpdateBlock)
 				if dbTx.Error != nil {
-					logx.Errorf("update block error, err: %s", dbTx.Error.Error())
 					return dbTx.Error
 				}
 				if dbTx.RowsAffected == 0 {
-					blocksInfo, err := json.Marshal(pendingUpdateBlocks)
 					if err != nil {
-						logx.Errorf("marshal block error, err: %s", err.Error())
 						return err
 					}
-					logx.Errorf("invalid block:  %s", string(blocksInfo))
 					return errors.New("invalid block")
 				}
 			}
@@ -153,7 +147,6 @@ func (m *defaultL1EventModel) CreateGenericBlock(
 				for _, detail := range pendingDeleteMempoolTx.MempoolDetails {
 					dbTx := tx.Table(mempool.DetailTableName).Where("id = ?", detail.ID).Delete(&detail)
 					if dbTx.Error != nil {
-						logx.Errorf("delete tx detail error, err: %s", dbTx.Error.Error())
 						return dbTx.Error
 					}
 					if dbTx.RowsAffected == 0 {
@@ -162,7 +155,6 @@ func (m *defaultL1EventModel) CreateGenericBlock(
 				}
 				dbTx := tx.Table(mempool.MempoolTableName).Where("id = ?", pendingDeleteMempoolTx.ID).Delete(&pendingDeleteMempoolTx)
 				if dbTx.Error != nil {
-					logx.Errorf("delete mempool tx error, err: %s", dbTx.Error.Error())
 					return dbTx.Error
 				}
 				if dbTx.RowsAffected == 0 {
@@ -199,7 +191,6 @@ func (m *defaultL1EventModel) CreateGovernanceBlock(
 					return dbTx.Error
 				}
 				if dbTx.RowsAffected != int64(len(pendingNewL2Assets)) {
-					logx.Errorf("the length of created rows doesn't match, created=%d, toCreate=%s", dbTx.RowsAffected, len(pendingNewL2Assets))
 					return errors.New("invalid l2 asset info")
 				}
 			}
@@ -217,7 +208,6 @@ func (m *defaultL1EventModel) CreateGovernanceBlock(
 					return dbTx.Error
 				}
 				if dbTx.RowsAffected != int64(len(pendingNewSysConfigs)) {
-					logx.Errorf("the length of created rows doesn't match, created=%d, toCreate=%s", dbTx.RowsAffected, len(pendingNewSysConfigs))
 					return errors.New("invalid sys config info")
 				}
 			}
@@ -237,7 +227,6 @@ func (m *defaultL1EventModel) CreateGovernanceBlock(
 func (m *defaultL1EventModel) GetLatestL1BlockByType(blockType int) (blockInfo *L1SyncedBlock, err error) {
 	dbTx := m.DB.Table(m.table).Where("type = ?", blockType).Order("l1_block_height desc").Find(&blockInfo)
 	if dbTx.Error != nil {
-		logx.Errorf("get synced blocks error, err: %s", err.Error())
 		return nil, types.DbErrSqlOperation
 	}
 	if dbTx.RowsAffected == 0 {

--- a/dao/liquidity/liquidity.go
+++ b/dao/liquidity/liquidity.go
@@ -18,7 +18,6 @@
 package liquidity
 
 import (
-	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stores/cache"
 	"github.com/zeromicro/go-zero/core/stores/sqlc"
 	"github.com/zeromicro/go-zero/core/stores/sqlx"
@@ -83,7 +82,6 @@ func (m *defaultLiquidityModel) DropLiquidityTable() error {
 func (m *defaultLiquidityModel) GetLiquidityByPairIndex(pairIndex int64) (entity *Liquidity, err error) {
 	dbTx := m.DB.Table(m.table).Where("pair_index = ?", pairIndex).Find(&entity)
 	if dbTx.Error != nil {
-		logx.Errorf("get liquidity by pair index error, err: %s", dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound

--- a/dao/liquidity/liquidity_history.go
+++ b/dao/liquidity/liquidity_history.go
@@ -18,7 +18,6 @@
 package liquidity
 
 import (
-	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stores/cache"
 	"github.com/zeromicro/go-zero/core/stores/sqlc"
 	"github.com/zeromicro/go-zero/core/stores/sqlx"
@@ -91,7 +90,6 @@ func (m *defaultLiquidityHistoryModel) GetLatestLiquidityByBlockHeight(blockHeig
 		Order("pair_index")
 
 	if dbTx.Find(&entities).Error != nil {
-		logx.Errorf("unable to get related accounts: %s", dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound
@@ -107,7 +105,6 @@ func (m *defaultLiquidityHistoryModel) GetLatestLiquidityCountByBlockHeight(bloc
 		Where("NOT EXISTS (?) AND l2_block_height <= ?", subQuery, blockHeight)
 
 	if dbTx.Count(&count).Error != nil {
-		logx.Errorf("[GetLatestLiquidityCountByBlockHeight] unable to get related accounts: %s", dbTx.Error.Error())
 		return 0, dbTx.Error
 	}
 	return count, nil

--- a/dao/mempool/mempool_detail.go
+++ b/dao/mempool/mempool_detail.go
@@ -20,7 +20,6 @@ package mempool
 import (
 	"time"
 
-	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stores/cache"
 	"github.com/zeromicro/go-zero/core/stores/sqlc"
 	"github.com/zeromicro/go-zero/core/stores/sqlx"
@@ -88,7 +87,6 @@ func (m *defaultMempoolDetailModel) GetMempoolTxDetailsByAccountIndex(accountInd
 	var dbTx *gorm.DB
 	dbTx = m.DB.Table(m.table).Where("account_index = ?", accountIndex).Find(&mempoolTxDetails)
 	if dbTx.Error != nil {
-		logx.Errorf("unable to get by account index: %s", dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound

--- a/dao/nft/nft.go
+++ b/dao/nft/nft.go
@@ -18,7 +18,6 @@
 package nft
 
 import (
-	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stores/cache"
 	"github.com/zeromicro/go-zero/core/stores/sqlc"
 	"github.com/zeromicro/go-zero/core/stores/sqlx"
@@ -82,7 +81,6 @@ func (m *defaultL2NftModel) DropL2NftTable() error {
 func (m *defaultL2NftModel) GetNftAsset(nftIndex int64) (nftAsset *L2Nft, err error) {
 	dbTx := m.DB.Table(m.table).Where("nft_index = ?", nftIndex).Find(&nftAsset)
 	if dbTx.Error != nil {
-		logx.Errorf("unable to get nft asset: %s", dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound
@@ -94,7 +92,6 @@ func (m *defaultL2NftModel) GetLatestNftIndex() (nftIndex int64, err error) {
 	var nftInfo *L2Nft
 	dbTx := m.DB.Table(m.table).Order("nft_index desc").Find(&nftInfo)
 	if dbTx.Error != nil {
-		logx.Errorf("unable to get latest nft info: %s", dbTx.Error.Error())
 		return -1, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return -1, nil
@@ -106,7 +103,6 @@ func (m *defaultL2NftModel) GetNftListByAccountIndex(accountIndex, limit, offset
 	dbTx := m.DB.Table(m.table).Where("owner_account_index = ? and deleted_at is NULL", accountIndex).
 		Limit(int(limit)).Offset(int(offset)).Order("nft_index desc").Find(&nftList)
 	if dbTx.Error != nil {
-		logx.Errorf("fail to get nfts by account: %d, offset: %d, limit: %d, error: %s", accountIndex, offset, limit, dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound
@@ -118,7 +114,6 @@ func (m *defaultL2NftModel) GetAccountNftTotalCount(accountIndex int64) (int64, 
 	var count int64
 	dbTx := m.DB.Table(m.table).Where("owner_account_index = ? and deleted_at is NULL", accountIndex).Count(&count)
 	if dbTx.Error != nil {
-		logx.Errorf("fail to get nft count by account: %d, error: %s", accountIndex, dbTx.Error.Error())
 		return 0, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return 0, types.DbErrNotFound

--- a/dao/nft/nft_collection.go
+++ b/dao/nft/nft_collection.go
@@ -18,7 +18,6 @@
 package nft
 
 import (
-	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stores/cache"
 	"github.com/zeromicro/go-zero/core/stores/sqlc"
 	"github.com/zeromicro/go-zero/core/stores/sqlx"
@@ -78,7 +77,6 @@ func (m *defaultL2NftCollectionModel) IfCollectionExistsByCollectionId(accountIn
 	dbTx := m.DB.Table(m.table).Where("account_index = ? and collection_id = ? and deleted_at is NULL", accountIndex, collectionId).Count(&res)
 
 	if dbTx.Error != nil {
-		logx.Errorf("get collection count error, err: %s", dbTx.Error.Error())
 		return true, types.DbErrSqlOperation
 	} else if res == 0 {
 		return false, nil

--- a/dao/nft/nft_history.go
+++ b/dao/nft/nft_history.go
@@ -18,7 +18,6 @@
 package nft
 
 import (
-	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stores/cache"
 	"github.com/zeromicro/go-zero/core/stores/sqlc"
 	"github.com/zeromicro/go-zero/core/stores/sqlx"
@@ -93,7 +92,6 @@ func (m *defaultL2NftHistoryModel) GetLatestNftAssetCountByBlockHeight(height in
 		Where("NOT EXISTS (?) AND l2_block_height <= ?", subQuery, height)
 
 	if dbTx.Count(&count).Error != nil {
-		logx.Errorf("[GetLatestNftAssetCountByBlockHeight] unable to get related nft assets: %s", dbTx.Error.Error())
 		return 0, types.DbErrSqlOperation
 	}
 
@@ -112,7 +110,6 @@ func (m *defaultL2NftHistoryModel) GetLatestNftAssetsByBlockHeight(height int64,
 		Order("nft_index")
 
 	if dbTx.Find(&accountNftAssets).Error != nil {
-		logx.Errorf("[GetLatestNftAssetsByBlockHeight] unable to get related nft assets: %s", dbTx.Error.Error())
 		return 0, nil, types.DbErrSqlOperation
 	}
 	return dbTx.RowsAffected, accountNftAssets, nil

--- a/dao/nft/offer.go
+++ b/dao/nft/offer.go
@@ -18,7 +18,6 @@
 package nft
 
 import (
-	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stores/cache"
 	"github.com/zeromicro/go-zero/core/stores/sqlc"
 	"github.com/zeromicro/go-zero/core/stores/sqlx"
@@ -86,7 +85,6 @@ func (m *defaultOfferModel) GetLatestOfferId(accountIndex int64) (offerId int64,
 	var offer *Offer
 	dbTx := m.DB.Table(m.table).Where("account_index = ?", accountIndex).Order("offer_id desc").Find(&offer)
 	if dbTx.Error != nil {
-		logx.Errorf("[GetLatestOfferId] unable to get latest offer info: %s", dbTx.Error.Error())
 		return -1, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return -1, types.DbErrNotFound
@@ -97,10 +95,8 @@ func (m *defaultOfferModel) GetLatestOfferId(accountIndex int64) (offerId int64,
 func (m *defaultOfferModel) GetOfferByAccountIndexAndOfferId(accountIndex int64, offerId int64) (offer *Offer, err error) {
 	dbTx := m.DB.Table(m.table).Where("account_index = ? AND offer_id = ?", accountIndex, offerId).Find(&offer)
 	if dbTx.Error != nil {
-		logx.Errorf("[CreateOffer] unable to create offer: %s", dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
-		logx.Errorf("[CreateOffer] invalid offer info")
 		return nil, types.DbErrNotFound
 	}
 	return offer, nil

--- a/dao/proof/proof.go
+++ b/dao/proof/proof.go
@@ -17,7 +17,6 @@
 package proof
 
 import (
-	"github.com/zeromicro/go-zero/core/logx"
 	"gorm.io/gorm"
 
 	"github.com/bnb-chain/zkbas/types"
@@ -78,7 +77,6 @@ func (m *defaultProofModel) DropProofTable() error {
 func (m *defaultProofModel) CreateProof(row *Proof) error {
 	dbTx := m.DB.Table(m.table).Create(row)
 	if dbTx.Error != nil {
-		logx.Errorf("create proof error, err: %s", dbTx.Error.Error())
 		return dbTx.Error
 	}
 	if dbTx.RowsAffected == 0 {
@@ -96,7 +94,6 @@ func (m *defaultProofModel) GetProofsBetween(start int64, end int64) (proofs []*
 		Find(&proofs)
 
 	if dbTx.Error != nil {
-		logx.Errorf("get proofs error, err: %s", dbTx.Error.Error())
 		return proofs, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound
@@ -109,7 +106,6 @@ func (m *defaultProofModel) GetLatestConfirmedProof() (p *Proof, err error) {
 	var row *Proof
 	dbTx := m.DB.Table(m.table).Where("status >= ?", NotConfirmed).Order("block_number desc").Limit(1).Find(&row)
 	if dbTx.Error != nil {
-		logx.Errorf("get confirmed proof error, err; %s", dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound
@@ -122,7 +118,6 @@ func (m *defaultProofModel) GetProofByBlockNumber(num int64) (p *Proof, err erro
 	var row *Proof
 	dbTx := m.DB.Table(m.table).Where("block_number = ?", num).Find(&row)
 	if dbTx.Error != nil {
-		logx.Errorf("get proof error, err: %s", dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound

--- a/dao/sysconfig/sysconfig.go
+++ b/dao/sysconfig/sysconfig.go
@@ -18,7 +18,6 @@
 package sysconfig
 
 import (
-	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stores/cache"
 	"github.com/zeromicro/go-zero/core/stores/sqlc"
 	"github.com/zeromicro/go-zero/core/stores/sqlx"
@@ -77,7 +76,6 @@ func (m *defaultSysConfigModel) DropSysConfigTable() error {
 func (m *defaultSysConfigModel) GetSysConfigByName(name string) (config *SysConfig, err error) {
 	dbTx := m.DB.Table(m.table).Where("name = ?", name).Find(&config)
 	if dbTx.Error != nil {
-		logx.Errorf("get sys config by name error, err: %s", dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound
@@ -88,7 +86,6 @@ func (m *defaultSysConfigModel) GetSysConfigByName(name string) (config *SysConf
 func (m *defaultSysConfigModel) CreateSysConfigInBatches(configs []*SysConfig) (rowsAffected int64, err error) {
 	dbTx := m.DB.Table(m.table).CreateInBatches(configs, len(configs))
 	if dbTx.Error != nil {
-		logx.Errorf("create sys configs error, err: %s", dbTx.Error.Error())
 		return 0, types.DbErrSqlOperation
 	}
 	if dbTx.RowsAffected == 0 {

--- a/dao/tx/fail_tx.go
+++ b/dao/tx/fail_tx.go
@@ -18,7 +18,6 @@
 package tx
 
 import (
-	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stores/cache"
 	"github.com/zeromicro/go-zero/core/stores/sqlc"
 	"github.com/zeromicro/go-zero/core/stores/sqlx"
@@ -84,7 +83,6 @@ func (m *defaultFailTxModel) DropFailTxTable() error {
 func (m *defaultFailTxModel) CreateFailTx(failTx *FailTx) error {
 	dbTx := m.DB.Table(m.table).Create(failTx)
 	if dbTx.Error != nil {
-		logx.Errorf("create fail tx error, err: %s", dbTx.Error.Error())
 		return types.DbErrSqlOperation
 	}
 	if dbTx.RowsAffected == 0 {

--- a/dao/tx/tx.go
+++ b/dao/tx/tx.go
@@ -21,7 +21,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stores/cache"
 	"github.com/zeromicro/go-zero/core/stores/sqlc"
 	"github.com/zeromicro/go-zero/core/stores/sqlx"
@@ -115,7 +114,6 @@ func (m *defaultTxModel) GetTxsTotalCount() (count int64, err error) {
 		if dbTx.Error == types.DbErrNotFound {
 			return 0, nil
 		}
-		logx.Errorf("get tx total count error, err: %s", dbTx.Error.Error())
 		return 0, types.DbErrSqlOperation
 	}
 	return count, nil
@@ -124,7 +122,6 @@ func (m *defaultTxModel) GetTxsTotalCount() (count int64, err error) {
 func (m *defaultTxModel) GetTxsList(limit int64, offset int64) (txList []*Tx, err error) {
 	dbTx := m.DB.Table(m.table).Limit(int(limit)).Offset(int(offset)).Order("created_at desc").Find(&txList)
 	if dbTx.Error != nil {
-		logx.Errorf("fail to get txs, offset: %d, limit: %d, error: %s", offset, limit, dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound
@@ -135,7 +132,6 @@ func (m *defaultTxModel) GetTxsList(limit int64, offset int64) (txList []*Tx, er
 func (m *defaultTxModel) GetTxsListByAccountIndex(accountIndex int64, limit int64, offset int64) (txList []*Tx, err error) {
 	dbTx := m.DB.Table(m.table).Where("account_index = ?", accountIndex).Limit(int(limit)).Offset(int(offset)).Order("created_at desc").Find(&txList)
 	if dbTx.Error != nil {
-		logx.Errorf("fail to get txs by account index: %d, offset: %d, limit: %d, error: %s", accountIndex, offset, limit, dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound
@@ -146,7 +142,6 @@ func (m *defaultTxModel) GetTxsListByAccountIndex(accountIndex int64, limit int6
 func (m *defaultTxModel) GetTxsCountByAccountIndex(accountIndex int64) (count int64, err error) {
 	dbTx := m.DB.Table(m.table).Where("account_index = ?", accountIndex).Count(&count)
 	if dbTx.Error != nil {
-		logx.Errorf("fail to get tx count by account: %d, error: %s", accountIndex, dbTx.Error.Error())
 		return 0, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return 0, nil
@@ -157,7 +152,6 @@ func (m *defaultTxModel) GetTxsCountByAccountIndex(accountIndex int64) (count in
 func (m *defaultTxModel) GetTxsListByAccountIndexTxType(accountIndex int64, txType int64, limit int64, offset int64) (txList []*Tx, err error) {
 	dbTx := m.DB.Table(m.table).Where("account_index = ? and tx_type = ?", accountIndex, txType).Limit(int(limit)).Offset(int(offset)).Order("created_at desc").Find(&txList)
 	if dbTx.Error != nil {
-		logx.Errorf("fail to get txs by account index: %d, tx type:%d, offset: %d, limit: %d, error: %s", accountIndex, txType, offset, limit, dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound
@@ -168,7 +162,6 @@ func (m *defaultTxModel) GetTxsListByAccountIndexTxType(accountIndex int64, txTy
 func (m *defaultTxModel) GetTxsCountByAccountIndexTxType(accountIndex int64, txType int64) (count int64, err error) {
 	dbTx := m.DB.Table(m.table).Where("account_index = ? and tx_type = ?", accountIndex, txType).Count(&count)
 	if dbTx.Error != nil {
-		logx.Errorf("fail to get tx count by account: %d, tx type: %d, error: %s", accountIndex, txType, dbTx.Error.Error())
 		return 0, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return 0, nil
@@ -181,14 +174,12 @@ func (m *defaultTxModel) GetTxByHash(txHash string) (tx *Tx, err error) {
 
 	dbTx := m.DB.Table(m.table).Where("tx_hash = ?", txHash).Find(&tx)
 	if dbTx.Error != nil {
-		logx.Errorf("get tx by hash error, err: %s", dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound
 	}
 	err = m.DB.Model(&tx).Association(txForeignKeyColumn).Find(&tx.TxDetails)
 	if err != nil {
-		logx.Errorf("get associate tx details error, err: %s", err.Error())
 		return nil, err
 	}
 	// re-order tx details
@@ -204,14 +195,12 @@ func (m *defaultTxModel) GetTxById(id int64) (tx *Tx, err error) {
 
 	dbTx := m.DB.Table(m.table).Where("id = ?", id).Find(&tx)
 	if dbTx.Error != nil {
-		logx.Errorf("get tx by id error, err: %s", dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound
 	}
 	err = m.DB.Model(&tx).Association(txForeignKeyColumn).Find(&tx.TxDetails)
 	if err != nil {
-		logx.Errorf("get associate tx details error, err: %s", err.Error())
 		return nil, err
 	}
 	// re-order tx details
@@ -225,7 +214,6 @@ func (m *defaultTxModel) GetTxById(id int64) (tx *Tx, err error) {
 func (m *defaultTxModel) GetTxsTotalCountBetween(from, to time.Time) (count int64, err error) {
 	dbTx := m.DB.Table(m.table).Where("created_at BETWEEN ? AND ?", from, to).Count(&count)
 	if dbTx.Error != nil {
-		logx.Errorf("fail to get tx by time range: %d-%d, error: %s", from.Unix(), to.Unix(), dbTx.Error.Error())
 		return 0, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return 0, nil
@@ -236,7 +224,6 @@ func (m *defaultTxModel) GetTxsTotalCountBetween(from, to time.Time) (count int6
 func (m *defaultTxModel) GetDistinctAccountsCountBetween(from, to time.Time) (count int64, err error) {
 	dbTx := m.DB.Raw("SELECT account_index FROM tx WHERE created_at BETWEEN ? AND ? AND account_index != -1 GROUP BY account_index", from, to).Count(&count)
 	if dbTx.Error != nil {
-		logx.Errorf("fail to get dau by time range: %d-%d, error: %s", from.Unix(), to.Unix(), dbTx.Error.Error())
 		return 0, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return 0, nil

--- a/dao/tx/txdetail.go
+++ b/dao/tx/txdetail.go
@@ -20,7 +20,6 @@ package tx
 import (
 	"sort"
 
-	"github.com/zeromicro/go-zero/core/logx"
 	"github.com/zeromicro/go-zero/core/stores/cache"
 	"github.com/zeromicro/go-zero/core/stores/sqlc"
 	"github.com/zeromicro/go-zero/core/stores/sqlx"
@@ -84,7 +83,6 @@ func (m *defaultTxDetailModel) DropTxDetailTable() error {
 func (m *defaultTxDetailModel) GetTxDetailByAccountIndex(accountIndex int64) (txDetails []*TxDetail, err error) {
 	dbTx := m.DB.Table(m.table).Where("account_index = ?", accountIndex).Find(&txDetails)
 	if dbTx.Error != nil {
-		logx.Errorf("fail to get tx details by account: %d, error: %s", accountIndex, dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound
@@ -95,7 +93,6 @@ func (m *defaultTxDetailModel) GetTxDetailByAccountIndex(accountIndex int64) (tx
 func (m *defaultTxDetailModel) GetTxIdsByAccountIndex(accountIndex int64) (txIds []int64, err error) {
 	dbTx := m.DB.Table(m.table).Select("tx_id").Where("account_index = ?", accountIndex).Group("tx_id").Find(&txIds)
 	if dbTx.Error != nil {
-		logx.Errorf("fail to get tx ids by account: %d, error: %s", accountIndex, dbTx.Error.Error())
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {
 		return nil, types.DbErrNotFound

--- a/service/monitor/main.go
+++ b/service/monitor/main.go
@@ -32,7 +32,7 @@ func main() {
 	if _, err := cronjob.AddFunc("@every 10s", func() {
 		err := m.MonitorGenericBlocks()
 		if err != nil {
-			logx.Errorf("monitor blocks error, err=%s", err.Error())
+			logx.Errorf("monitor blocks error, %v", err)
 		}
 	}); err != nil {
 		panic(err)
@@ -42,7 +42,7 @@ func main() {
 	if _, err := cronjob.AddFunc("@every 10s", func() {
 		err := m.MonitorPriorityRequests()
 		if err != nil {
-			logx.Errorf("monitor priority requests error, err=%s", err.Error())
+			logx.Errorf("monitor priority requests error, %v", err)
 		}
 	}); err != nil {
 		panic(err)
@@ -52,7 +52,7 @@ func main() {
 	if _, err := cronjob.AddFunc("@every 10s", func() {
 		err := m.MonitorGovernanceBlocks()
 		if err != nil {
-			logx.Errorf("monitor governance blocks error, err=%s", err.Error())
+			logx.Errorf("monitor governance blocks error, %v", err)
 		}
 
 	}); err != nil {

--- a/service/monitor/monitor/monitor_priority_requests.go
+++ b/service/monitor/monitor/monitor_priority_requests.go
@@ -18,10 +18,9 @@ package monitor
 
 import (
 	"encoding/json"
-	"errors"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/zeromicro/go-zero/core/logx"
 
 	"github.com/bnb-chain/zkbas/common/chain"
 	"github.com/bnb-chain/zkbas/dao/mempool"
@@ -31,13 +30,10 @@ import (
 func (m *Monitor) MonitorPriorityRequests() error {
 	pendingRequests, err := m.PriorityRequestModel.GetPriorityRequestsByStatus(PendingStatus)
 	if err != nil {
-		if err == types.DbErrNotFound {
-			logx.Info("no pending requests")
-			return err
-		} else {
-			logx.Error("unable to get pending requests")
+		if err != types.DbErrNotFound {
 			return err
 		}
+		return nil
 	}
 	var (
 		pendingNewMempoolTxs []*mempool.MempoolTx
@@ -45,15 +41,13 @@ func (m *Monitor) MonitorPriorityRequests() error {
 	// get last handled request id
 	currentRequestId, err := m.PriorityRequestModel.GetLatestHandledRequestId()
 	if err != nil {
-		logx.Errorf("unable to get last handled request id: %s", err.Error())
-		return err
+		return fmt.Errorf("unable to get last handled request id, err: %v", err)
 	}
 
 	for _, request := range pendingRequests {
 		// request id must be in order
 		if request.RequestId != currentRequestId+1 {
-			logx.Errorf("invalid request id")
-			return errors.New("invalid request id")
+			return fmt.Errorf("invalid request id")
 		}
 		currentRequestId++
 
@@ -80,13 +74,11 @@ func (m *Monitor) MonitorPriorityRequests() error {
 			// parse request info
 			txInfo, err := chain.ParseRegisterZnsPubData(common.FromHex(request.Pubdata))
 			if err != nil {
-				logx.Errorf("unable to parse registerZNS pub data: %s", err.Error())
-				return err
+				return fmt.Errorf("unable to parse registerZNS pub data, err: %v", err)
 			}
 
 			txInfoBytes, err := json.Marshal(txInfo)
 			if err != nil {
-				logx.Errorf("unable to serialize request info : %s", err.Error())
 				return err
 			}
 
@@ -97,14 +89,12 @@ func (m *Monitor) MonitorPriorityRequests() error {
 		case TxTypeCreatePair:
 			txInfo, err := chain.ParseCreatePairPubData(common.FromHex(request.Pubdata))
 			if err != nil {
-				logx.Errorf("unable to parse registerZNS pub data: %s", err.Error())
-				return err
+				return fmt.Errorf("unable to parse registerZNS pub data: %v", err)
 			}
 
 			txInfoBytes, err := json.Marshal(txInfo)
 			if err != nil {
-				logx.Errorf("unable to serialize request info : %s", err.Error())
-				return err
+				return fmt.Errorf("unable to serialize request info : %v", err)
 			}
 
 			mempoolTx.TxType = int64(txInfo.TxType)
@@ -115,14 +105,12 @@ func (m *Monitor) MonitorPriorityRequests() error {
 		case TxTypeUpdatePairRate:
 			txInfo, err := chain.ParseUpdatePairRatePubData(common.FromHex(request.Pubdata))
 			if err != nil {
-				logx.Errorf("unable to parse update pair rate pub data: %s", err.Error())
-				return err
+				return fmt.Errorf("unable to parse update pair rate pub data: %v", err)
 			}
 
 			txInfoBytes, err := json.Marshal(txInfo)
 			if err != nil {
-				logx.Errorf("unable to serialize request info : %s", err.Error())
-				return err
+				return fmt.Errorf("unable to serialize request info : %v", err)
 			}
 
 			mempoolTx.TxType = int64(txInfo.TxType)
@@ -132,14 +120,13 @@ func (m *Monitor) MonitorPriorityRequests() error {
 		case TxTypeDeposit:
 			txInfo, err := chain.ParseDepositPubData(common.FromHex(request.Pubdata))
 			if err != nil {
-				logx.Errorf("unable to parse deposit pub data: %s", err.Error())
+				fmt.Errorf("unable to parse deposit pub data: %v", err)
 				return err
 			}
 
 			txInfoBytes, err := json.Marshal(txInfo)
 			if err != nil {
-				logx.Errorf("unable to serialize request info : %s", err.Error())
-				return err
+				return fmt.Errorf("unable to serialize request info : %v", err)
 			}
 
 			mempoolTx.TxType = int64(txInfo.TxType)
@@ -152,14 +139,12 @@ func (m *Monitor) MonitorPriorityRequests() error {
 		case TxTypeDepositNft:
 			txInfo, err := chain.ParseDepositNftPubData(common.FromHex(request.Pubdata))
 			if err != nil {
-				logx.Errorf("unable to parse deposit nft pub data: %s", err.Error())
-				return err
+				return fmt.Errorf("unable to parse deposit nft pub data: %v", err)
 			}
 
 			txInfoBytes, err := json.Marshal(txInfo)
 			if err != nil {
-				logx.Errorf("unable to serialize request info: %s", err.Error())
-				return err
+				return fmt.Errorf("unable to serialize request info: %v", err)
 			}
 
 			mempoolTx.TxType = int64(txInfo.TxType)
@@ -170,14 +155,12 @@ func (m *Monitor) MonitorPriorityRequests() error {
 		case TxTypeFullExit:
 			txInfo, err := chain.ParseFullExitPubData(common.FromHex(request.Pubdata))
 			if err != nil {
-				logx.Errorf("unable to parse deposit pub data: %s", err.Error())
-				return err
+				return fmt.Errorf("unable to parse deposit pub data: %v", err)
 			}
 
 			txInfoBytes, err := json.Marshal(txInfo)
 			if err != nil {
-				logx.Errorf("unable to serialize request info : %s", err.Error())
-				return err
+				return fmt.Errorf("unable to serialize request info : %v", err)
 			}
 
 			mempoolTx.TxType = int64(txInfo.TxType)
@@ -189,14 +172,12 @@ func (m *Monitor) MonitorPriorityRequests() error {
 		case TxTypeFullExitNft:
 			txInfo, err := chain.ParseFullExitNftPubData(common.FromHex(request.Pubdata))
 			if err != nil {
-				logx.Errorf("unable to parse deposit nft pub data: %s", err.Error())
-				return err
+				return fmt.Errorf("unable to parse deposit nft pub data: %v", err)
 			}
 
 			txInfoBytes, err := json.Marshal(txInfo)
 			if err != nil {
-				logx.Errorf("unable to serialize request info : %s", err.Error())
-				return err
+				return fmt.Errorf("unable to serialize request info : %v", err)
 			}
 
 			mempoolTx.TxType = int64(txInfo.TxType)
@@ -206,15 +187,13 @@ func (m *Monitor) MonitorPriorityRequests() error {
 
 			pendingNewMempoolTxs = append(pendingNewMempoolTxs, mempoolTx)
 		default:
-			logx.Errorf("invalid request type")
-			return errors.New("invalid request type")
+			return fmt.Errorf("invalid request type")
 		}
 	}
 
 	// update db
 	if err = m.PriorityRequestModel.CreateMempoolTxsAndUpdateRequests(pendingNewMempoolTxs, pendingRequests); err != nil {
-		logx.Errorf("unable to create mempool pendingRequests and update priority requests, error: %s", err.Error())
-		return err
+		return fmt.Errorf("unable to create mempool pendingRequests and update priority requests, error: %v", err)
 	}
 	return nil
 }

--- a/service/prover/main.go
+++ b/service/prover/main.go
@@ -34,14 +34,12 @@ func main() {
 		// cron job for receiving cryptoBlock and handling
 		err := p.ProveBlock()
 		if err != nil {
-			logx.Error("Prove Error: ", err.Error())
+			logx.Errorf("failed to generate proof, %v", err)
 		}
 	})
 	if err != nil {
 		panic(err)
 	}
 	cronJob.Start()
-
-	logx.Info("p cronjob is starting......")
 	select {}
 }

--- a/service/sender/main.go
+++ b/service/sender/main.go
@@ -35,7 +35,7 @@ func main() {
 		logx.Info("========================= start commit task =========================")
 		err := s.CommitBlocks()
 		if err != nil {
-			logx.Errorf("failed to rollup blocks: %v", err)
+			logx.Errorf("failed to rollup block, %v", err)
 		}
 	})
 	if err != nil {
@@ -46,7 +46,7 @@ func main() {
 		logx.Info("========================= start verify task =========================")
 		err = s.VerifyAndExecuteBlocks()
 		if err != nil {
-			logx.Errorf("failed to send verify transaction %v", err)
+			logx.Errorf("failed to send verify transaction, %v", err)
 		}
 	})
 	if err != nil {
@@ -57,7 +57,7 @@ func main() {
 		logx.Info("========================= start update txs task =========================")
 		err = s.UpdateSentTxs()
 		if err != nil {
-			logx.Errorf("failed to update update tx status, err: %v", err)
+			logx.Errorf("failed to update update tx status, %v", err)
 		}
 	})
 	if err != nil {

--- a/service/witness/main.go
+++ b/service/witness/main.go
@@ -19,7 +19,10 @@ func main() {
 
 	var c config.Config
 	conf.MustLoad(*configFile, &c)
-	w := witness.NewWitness(c)
+	w, err := witness.NewWitness(c)
+	if err != nil {
+		panic(err)
+	}
 	logx.MustSetup(c.LogConf)
 	logx.DisableStat()
 	proc.AddShutdownListener(func() {
@@ -29,13 +32,11 @@ func main() {
 	cronJob := cron.New(cron.WithChain(
 		cron.SkipIfStillRunning(cron.DiscardLogger),
 	))
-	_, err := cronJob.AddFunc("@every 2s", func() {
+	_, err = cronJob.AddFunc("@every 2s", func() {
 		logx.Info("==========start generate block witness==========")
 		err := w.GenerateBlockWitness()
 		if err != nil {
-			logx.Errorf("==========failed to generate block witness %v==========", err)
-		} else {
-			logx.Info("==========success generate block witness==========")
+			logx.Errorf("failed to generate block witness, %v", err)
 		}
 		w.RescheduleBlockWitness()
 	})


### PR DESCRIPTION
### Description
make logs info more concentrate and reduce useless logs

### Rationale
A lot of useless logs and duplicated logs.

Now the log system:
1. Never log in data access object.
2. Never log twice for the same error

### Example


### Changes
No