### PR TITLE
fix: fix prover generate proof twice

### DIFF
--- a/service/prover/prover/prover.go
+++ b/service/prover/prover/prover.go
@@ -163,7 +163,7 @@ func (p *Prover) ProveBlock() error {
 	// Check the existence of block proof.
 	_, err = p.ProofModel.GetProofByBlockNumber(blockWitness.Height)
 	if err == nil {
-		logx.Infof("blockProof of height %d exists", blockWitness.Height)
+		logx.Errorf("blockProof of height %d exists", blockWitness.Height)
 		return nil
 	}
 


### PR DESCRIPTION
### Description

Fix prover generate proof twice - the issue is caused by wrong error handling.

### Rationale

Bug fix.

### Example

NA

### Changes

Notable changes:
* Bug fix