### PR TITLE
core: fix write wrong key for redis

### DIFF
--- a/core/statedb/statedb.go
+++ b/core/statedb/statedb.go
@@ -140,11 +140,11 @@ func (s *StateDB) SyncStateCacheToRedis() error {
 	if err != nil {
 		return err
 	}
-	err = s.syncPendingStateToRedis(s.PendingNewLiquidityIndexMap, dbcache.AccountKeyByIndex, s.GetLiquidity)
+	err = s.syncPendingStateToRedis(s.PendingNewLiquidityIndexMap, dbcache.LiquidityKeyByIndex, s.GetLiquidity)
 	if err != nil {
 		return err
 	}
-	err = s.syncPendingStateToRedis(s.PendingNewNftIndexMap, dbcache.AccountKeyByIndex, s.GetNft)
+	err = s.syncPendingStateToRedis(s.PendingNewNftIndexMap, dbcache.NftKeyByIndex, s.GetNft)
 	if err != nil {
 		return err
 	}
@@ -154,11 +154,11 @@ func (s *StateDB) SyncStateCacheToRedis() error {
 	if err != nil {
 		return err
 	}
-	err = s.syncPendingStateToRedis(s.PendingUpdateLiquidityIndexMap, dbcache.AccountKeyByIndex, s.GetLiquidity)
+	err = s.syncPendingStateToRedis(s.PendingUpdateLiquidityIndexMap, dbcache.LiquidityKeyByIndex, s.GetLiquidity)
 	if err != nil {
 		return err
 	}
-	err = s.syncPendingStateToRedis(s.PendingUpdateNftIndexMap, dbcache.AccountKeyByIndex, s.GetNft)
+	err = s.syncPendingStateToRedis(s.PendingUpdateNftIndexMap, dbcache.NftKeyByIndex, s.GetNft)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description
Fix write the wrong key of Redis when flush data to it.

### Rationale
When the committer syncs the liquidity and NFT data to Redis, it is using the wrong key.

### Example

NA

### Changes

Notable changes:
* NA