### PR TITLE
apiserver: enable cors for apis

### DIFF
--- a/service/apiserver/server.go
+++ b/service/apiserver/server.go
@@ -20,7 +20,7 @@ func main() {
 	var c config.Config
 	conf.MustLoad(*configFile, &c)
 
-	server := rest.MustNewServer(c.RestConf)
+	server := rest.MustNewServer(c.RestConf, rest.WithCors())
 	defer server.Stop()
 
 	ctx := svc.NewServiceContext(c)


### PR DESCRIPTION
### Description

Enable cors for apis, which is needed for some apps to call apis in their webapp (with their own domain names).

### Rationale

Enable cors policy for frontend usage.

### Example

NA

### Changes

Notable changes:
* change api server cors settings