### PR TITLE
witness: add full integration testcases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
 .PHONY: zkbas-linux-arm zkbas-linux-arm-5 zkbas-linux-arm-6 zkbas-linux-arm-7 zkbas-linux-arm64
 .PHONY: zkbas-darwin zkbas-darwin-386 zkbas-darwin-amd64
 .PHONY: zkbas-windows zkbas-windows-386 zkbas-windows-amd64
+GOBIN?=${GOPATH}/bin
 
 API_SERVER = ./service/apiserver
 PACKAGES = \
@@ -17,7 +18,7 @@ PACKAGES = \
            	./types/...
 
 api-server:
-	cd $(API_SERVER) && goctl api go -api server.api -dir .;
+	cd $(API_SERVER) && ${GOBIN}/goctl api go -api server.api -dir .;
 	@echo "Done generate server api";
 
 deploy:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ ZkBAS starts its development based on [Zecrey](https://github.com/bnb-chain/zecr
 
 
 ## Document
-The `./docs` directory includes a lot of useful documentation. You can find detail design and tutorial [there](docs/over_view.md).
+The `./docs` directory includes a lot of useful documentation. You can find detail design and tutorial [there](docs/readme.md).
 
 ## Key Features
 

--- a/common/prove/witness_test.go
+++ b/common/prove/witness_test.go
@@ -19,7 +19,6 @@ package prove
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os/exec"
 	"testing"
@@ -52,9 +51,8 @@ var (
 func TestConstructTxWitness(t *testing.T) {
 	testDBSetup()
 	defer testDBShutdown()
-	// TODO add more test blocks when we finish all integration test
-	testBlockHeight := []int64{1}
-	for _, h := range testBlockHeight {
+	maxTestBlockHeight := int64(33)
+	for h := int64(1); h < maxTestBlockHeight; h++ {
 		witnessHelper, err := getWitnessHelper(h - 1)
 		assert.NoError(t, err)
 		b, err := blockModel.GetBlocksBetween(h, h)
@@ -103,10 +101,7 @@ func testDBSetup() {
 	testDBShutdown()
 	cmd := exec.Command("docker", "run", "--name", "postgres-ut", "-p", "5432:5432",
 		"-e", "POSTGRES_PASSWORD=Zkbas@123", "-e", "POSTGRES_USER=postgres", "-e", "POSTGRES_DB=zkbas",
-		"-e", "PGDATA=/var/lib/postgresql/pgdata", "-d", "ghcr.io/bnb-chain/zkbas/zkbas-ut-postgres:latest")
-	if errors.Is(cmd.Err, exec.ErrDot) {
-		cmd.Err = nil
-	}
+		"-e", "PGDATA=/var/lib/postgresql/pgdata", "-d", "ghcr.io/bnb-chain/zkbas/zkbas-ut-postgres:0.0.2")
 	if err := cmd.Run(); err != nil {
 		panic(err)
 	}

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -39,6 +39,7 @@ ZkBAS implement the following features so far:
 - [ZkBAS Protocol Design](./protocol.md)
 - [Quick Start Tutorial](./tutorial.md)
 - [Tokenomics](./tokenomics.md)
+- [API Reference](./api_reference.md)  
 - [Storage Layout](./storage_layout.md)
 - [Wallets](./wallets.md)
 <!--ts-->


### PR DESCRIPTION
### Description
This PR is to integrated all witness generation testcases.

### Rationale

### How UT works in this package

We need mock data to run the testcase under this package, the mock data is a 
snapshot of postgres after running the integration test. 

We just create a snapshot of `postgres` container and push it on github as a docker 
image and reuse it.

### How to create mock data docker images

After you have run the integration test, while the `postgres` container is not deleted:

`docker commit -m 'add zkbas mock data' postgres   zkbas-ut-postgres`
`docker tag zkbas-ut-postgres ghcr.io/bnb-chain/zkbas/zkbas-ut-postgres:latest`
`docker push ghcr.io/bnb-chain/zkbas/zkbas-ut-postgres:latest`

Note: you need login the docker registry before pushing.
```shell
export CR_PAT={your github token}
echo $CR_PAT | docker login ghcr.io -u {your user name}  --password-stdin
```



### Example
No

### Changes

Notable changes:
Need do `docker pull  ghcr.io/bnb-chain/zkbas/zkbas-ut-postgres:0.0.2` before make test