### PR TITLE
core: improve updating trees and preparing assets

### DIFF
--- a/core/block_processor.go
+++ b/core/block_processor.go
@@ -51,17 +51,12 @@ func (p *CommitProcessor) Process(tx *tx.Tx) error {
 	if err != nil {
 		panic(err)
 	}
-	err = executor.UpdateTrees()
-	if err != nil {
-		panic(err)
-	}
 	tx, err = executor.GetExecutedTx()
 	if err != nil {
 		panic(err)
 	}
 
 	p.bc.Statedb.Txs = append(p.bc.Statedb.Txs, tx)
-	p.bc.Statedb.StateRoot = tx.StateRoot
 
 	return nil
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -191,6 +191,12 @@ func (bc *BlockChain) commitNewBlock(blockSize int, createdAt int64) (*block.Blo
 		}
 	}
 
+	// Intermediate state root.
+	err := s.IntermediateRoot()
+	if err != nil {
+		return nil, nil, err
+	}
+
 	// Align pub data.
 	s.AlignPubData(blockSize)
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -192,7 +192,7 @@ func (bc *BlockChain) commitNewBlock(blockSize int, createdAt int64) (*block.Blo
 	}
 
 	// Intermediate state root.
-	err := s.IntermediateRoot()
+	err := s.IntermediateRoot(false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/core/executor/add_liquidity_executor.go
+++ b/core/executor/add_liquidity_executor.go
@@ -164,6 +164,10 @@ func (e *AddLiquidityExecutor) ApplyTransaction() error {
 	stateCache.PendingUpdateAccountIndexMap[treasuryAccount.AccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateLiquidityIndexMap[txInfo.PairIndex] = statedb.StateCachePending
+	stateCache.MarkAccountAssetsDirty(txInfo.FromAccountIndex, []int64{txInfo.GasFeeAssetId, txInfo.AssetAId, txInfo.AssetBId, txInfo.PairIndex})
+	stateCache.MarkAccountAssetsDirty(treasuryAccount.AccountIndex, []int64{txInfo.PairIndex})
+	stateCache.MarkAccountAssetsDirty(txInfo.GasAccountIndex, []int64{txInfo.GasFeeAssetId})
+	stateCache.MarkLiquidityDirty(txInfo.PairIndex)
 	return nil
 }
 
@@ -277,28 +281,6 @@ func (e *AddLiquidityExecutor) GeneratePubData() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.PubData = append(stateCache.PubData, pubData...)
-	return nil
-}
-
-func (e *AddLiquidityExecutor) UpdateTrees() error {
-	bc := e.bc
-	txInfo := e.txInfo
-
-	liquidityModel := bc.StateDB().LiquidityMap[txInfo.PairIndex]
-
-	accounts := []int64{txInfo.FromAccountIndex, liquidityModel.TreasuryAccountIndex, txInfo.GasAccountIndex}
-	assets := []int64{txInfo.AssetAId, txInfo.AssetBId, txInfo.PairIndex, txInfo.GasFeeAssetId}
-
-	err := bc.StateDB().UpdateAccountTree(accounts, assets)
-	if err != nil {
-		return err
-	}
-
-	err = bc.StateDB().UpdateLiquidityTree(txInfo.PairIndex)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/core/executor/add_liquidity_executor.go
+++ b/core/executor/add_liquidity_executor.go
@@ -38,12 +38,8 @@ func NewAddLiquidityExecutor(bc IBlockchain, tx *tx.Tx) (TxExecutor, error) {
 	}
 
 	return &AddLiquidityExecutor{
-		BaseExecutor: BaseExecutor{
-			bc:      bc,
-			tx:      tx,
-			iTxInfo: txInfo,
-		},
-		txInfo: txInfo,
+		BaseExecutor: NewBaseExecutor(bc, tx, txInfo),
+		txInfo:       txInfo,
 	}, nil
 }
 
@@ -56,23 +52,19 @@ func (e *AddLiquidityExecutor) Prepare() error {
 		return errors.New("internal error")
 	}
 
-	liquidityModel := e.bc.StateDB().LiquidityMap[txInfo.PairIndex]
-
-	accounts := []int64{txInfo.FromAccountIndex, liquidityModel.TreasuryAccountIndex, txInfo.GasAccountIndex}
-	assets := []int64{liquidityModel.AssetAId, liquidityModel.AssetBId, txInfo.AssetAId, txInfo.AssetBId, txInfo.PairIndex, txInfo.GasFeeAssetId}
-	err = e.bc.StateDB().PrepareAccountsAndAssets(accounts, assets)
-	if err != nil {
-		logx.Errorf("prepare accounts and assets failed: %s", err.Error())
-		return errors.New("internal error")
-	}
-
-	// add details to tx info
-	err = e.fillTxInfo()
+	// Mark the tree states that would be affected in this executor.
+	e.MarkLiquidityDirty(txInfo.PairIndex)
+	e.MarkAccountAssetsDirty(txInfo.FromAccountIndex, []int64{txInfo.GasFeeAssetId, txInfo.AssetAId, txInfo.AssetBId, txInfo.PairIndex})
+	liquidity := e.bc.StateDB().LiquidityMap[txInfo.PairIndex]
+	e.MarkAccountAssetsDirty(liquidity.TreasuryAccountIndex, []int64{txInfo.PairIndex})
+	e.MarkAccountAssetsDirty(txInfo.GasAccountIndex, []int64{txInfo.GasFeeAssetId})
+	err = e.BaseExecutor.Prepare()
 	if err != nil {
 		return err
 	}
 
-	return nil
+	// Add the right details to tx info.
+	return e.fillTxInfo()
 }
 
 func (e *AddLiquidityExecutor) VerifyInputs() error {
@@ -164,10 +156,7 @@ func (e *AddLiquidityExecutor) ApplyTransaction() error {
 	stateCache.PendingUpdateAccountIndexMap[treasuryAccount.AccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateLiquidityIndexMap[txInfo.PairIndex] = statedb.StateCachePending
-	stateCache.MarkAccountAssetsDirty(txInfo.FromAccountIndex, []int64{txInfo.GasFeeAssetId, txInfo.AssetAId, txInfo.AssetBId, txInfo.PairIndex})
-	stateCache.MarkAccountAssetsDirty(treasuryAccount.AccountIndex, []int64{txInfo.PairIndex})
-	stateCache.MarkAccountAssetsDirty(txInfo.GasAccountIndex, []int64{txInfo.GasFeeAssetId})
-	stateCache.MarkLiquidityDirty(txInfo.PairIndex)
+	e.SyncDirtyToStateCache()
 	return nil
 }
 

--- a/core/executor/add_liquidity_executor.go
+++ b/core/executor/add_liquidity_executor.go
@@ -156,8 +156,7 @@ func (e *AddLiquidityExecutor) ApplyTransaction() error {
 	stateCache.PendingUpdateAccountIndexMap[treasuryAccount.AccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateLiquidityIndexMap[txInfo.PairIndex] = statedb.StateCachePending
-	e.SyncDirtyToStateCache()
-	return nil
+	return e.BaseExecutor.ApplyTransaction()
 }
 
 func (e *AddLiquidityExecutor) fillTxInfo() error {

--- a/core/executor/atomic_match_executor.go
+++ b/core/executor/atomic_match_executor.go
@@ -190,8 +190,7 @@ func (e *AtomicMatchExecutor) ApplyTransaction() error {
 	stateCache.PendingUpdateAccountIndexMap[matchNft.CreatorAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateNftIndexMap[txInfo.SellOffer.NftIndex] = statedb.StateCachePending
-	e.SyncDirtyToStateCache()
-	return nil
+	return e.BaseExecutor.ApplyTransaction()
 }
 
 func (e *AtomicMatchExecutor) GeneratePubData() error {

--- a/core/executor/base_executor.go
+++ b/core/executor/base_executor.go
@@ -4,6 +4,8 @@ import (
 	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
+	"github.com/pkg/errors"
+	"github.com/zeromicro/go-zero/core/logx"
 )
 
 const (
@@ -15,9 +17,32 @@ type BaseExecutor struct {
 	bc      IBlockchain
 	tx      *tx.Tx
 	iTxInfo legendTxTypes.TxInfo
+
+	// Affected states.
+	dirtyAccountsAndAssetsMap map[int64]map[int64]bool
+	dirtyLiquidityMap         map[int64]bool
+	dirtyNftMap               map[int64]bool
+}
+
+func NewBaseExecutor(bc IBlockchain, tx *tx.Tx, txInfo legendTxTypes.TxInfo) BaseExecutor {
+	return BaseExecutor{
+		bc:      bc,
+		tx:      tx,
+		iTxInfo: txInfo,
+
+		dirtyAccountsAndAssetsMap: make(map[int64]map[int64]bool, 0),
+		dirtyLiquidityMap:         make(map[int64]bool, 0),
+		dirtyNftMap:               make(map[int64]bool, 0),
+	}
 }
 
 func (e *BaseExecutor) Prepare() error {
+	err := e.bc.StateDB().PrepareAccountsAndAssets(e.dirtyAccountsAndAssetsMap)
+	if err != nil {
+		logx.Errorf("prepare accounts and assets failed: %s", err.Error())
+		return errors.New("internal error")
+	}
+
 	return nil
 }
 
@@ -66,4 +91,49 @@ func (e *BaseExecutor) GetExecutedTx() (*tx.Tx, error) {
 
 func (e *BaseExecutor) GenerateTxDetails() ([]*tx.TxDetail, error) {
 	return nil, nil
+}
+
+func (e *BaseExecutor) MarkAccountAssetsDirty(accountIndex int64, assets []int64) {
+	if accountIndex < 0 {
+		return
+	}
+
+	_, ok := e.dirtyAccountsAndAssetsMap[accountIndex]
+	if !ok {
+		e.dirtyAccountsAndAssetsMap[accountIndex] = make(map[int64]bool, 0)
+	}
+
+	for _, assetIndex := range assets {
+		// Should never happen, but protect here.
+		if assetIndex < 0 {
+			continue
+		}
+		e.dirtyAccountsAndAssetsMap[accountIndex][assetIndex] = true
+	}
+}
+
+func (e *BaseExecutor) MarkLiquidityDirty(pairIndex int64) {
+	e.dirtyLiquidityMap[pairIndex] = true
+}
+
+func (e *BaseExecutor) MarkNftDirty(nftIndex int64) {
+	e.dirtyNftMap[nftIndex] = true
+}
+
+func (e *BaseExecutor) SyncDirtyToStateCache() {
+	for accountIndex, assetsMap := range e.dirtyAccountsAndAssetsMap {
+		assets := make([]int64, 0, len(assetsMap))
+		for assetIndex := range assetsMap {
+			assets = append(assets, assetIndex)
+		}
+		e.bc.StateDB().MarkAccountAssetsDirty(accountIndex, assets)
+	}
+
+	for pairIndex := range e.dirtyLiquidityMap {
+		e.bc.StateDB().MarkLiquidityDirty(pairIndex)
+	}
+
+	for nftIndex := range e.dirtyNftMap {
+		e.bc.StateDB().MarkNftDirty(nftIndex)
+	}
 }

--- a/core/executor/base_executor.go
+++ b/core/executor/base_executor.go
@@ -57,14 +57,10 @@ func (e *BaseExecutor) GeneratePubData() error {
 	return nil
 }
 
-func (e *BaseExecutor) UpdateTrees() error {
-	return nil
-}
-
 func (e *BaseExecutor) GetExecutedTx() (*tx.Tx, error) {
 	e.tx.BlockHeight = e.bc.CurrentBlock().BlockHeight
-	e.tx.StateRoot = e.bc.StateDB().GetStateRoot()
-	e.tx.TxStatus = tx.StatusPending
+	e.tx.TxStatus = tx.StatusSuccess
+	e.tx.TxIndex = int64(len(e.bc.StateDB().Txs))
 	return e.tx, nil
 }
 

--- a/core/executor/base_executor.go
+++ b/core/executor/base_executor.go
@@ -1,11 +1,12 @@
 package executor
 
 import (
+	"github.com/pkg/errors"
+	"github.com/zeromicro/go-zero/core/logx"
+
 	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
-	"github.com/pkg/errors"
-	"github.com/zeromicro/go-zero/core/logx"
 )
 
 const (
@@ -75,6 +76,7 @@ func (e *BaseExecutor) VerifyInputs() error {
 }
 
 func (e *BaseExecutor) ApplyTransaction() error {
+	e.SyncDirtyToStateCache()
 	return nil
 }
 

--- a/core/executor/cancel_offer_executor.go
+++ b/core/executor/cancel_offer_executor.go
@@ -104,7 +104,8 @@ func (e *CancelOfferExecutor) ApplyTransaction() error {
 	stateCache := e.bc.StateDB()
 	stateCache.PendingUpdateAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
-
+	stateCache.MarkAccountAssetsDirty(txInfo.AccountIndex, []int64{txInfo.GasFeeAssetId, offerAssetId})
+	stateCache.MarkAccountAssetsDirty(txInfo.GasAccountIndex, []int64{txInfo.GasFeeAssetId})
 	return nil
 }
 
@@ -135,22 +136,6 @@ func (e *CancelOfferExecutor) GeneratePubData() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.PubData = append(stateCache.PubData, pubData...)
-	return nil
-}
-
-func (e *CancelOfferExecutor) UpdateTrees() error {
-	txInfo := e.txInfo
-
-	offerAssetId := txInfo.OfferId / OfferPerAsset
-	accounts := []int64{txInfo.AccountIndex, txInfo.GasAccountIndex}
-	assets := []int64{offerAssetId, txInfo.GasFeeAssetId}
-
-	err := e.bc.StateDB().UpdateAccountTree(accounts, assets)
-	if err != nil {
-		logx.Errorf("update account tree error, err: %s", err.Error())
-		return err
-	}
-
 	return nil
 }
 

--- a/core/executor/cancel_offer_executor.go
+++ b/core/executor/cancel_offer_executor.go
@@ -95,8 +95,7 @@ func (e *CancelOfferExecutor) ApplyTransaction() error {
 	stateCache := e.bc.StateDB()
 	stateCache.PendingUpdateAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
-	e.SyncDirtyToStateCache()
-	return nil
+	return e.BaseExecutor.ApplyTransaction()
 }
 
 func (e *CancelOfferExecutor) GeneratePubData() error {

--- a/core/executor/create_collection_executor.go
+++ b/core/executor/create_collection_executor.go
@@ -87,8 +87,7 @@ func (e *CreateCollectionExecutor) ApplyTransaction() error {
 	stateCache := e.bc.StateDB()
 	stateCache.PendingUpdateAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
-	e.SyncDirtyToStateCache()
-	return nil
+	return e.BaseExecutor.ApplyTransaction()
 }
 
 func (e *CreateCollectionExecutor) GeneratePubData() error {

--- a/core/executor/create_collection_executor.go
+++ b/core/executor/create_collection_executor.go
@@ -93,6 +93,8 @@ func (e *CreateCollectionExecutor) ApplyTransaction() error {
 	stateCache := e.bc.StateDB()
 	stateCache.PendingUpdateAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
+	stateCache.MarkAccountAssetsDirty(txInfo.AccountIndex, []int64{txInfo.GasFeeAssetId})
+	stateCache.MarkAccountAssetsDirty(txInfo.GasAccountIndex, []int64{txInfo.GasFeeAssetId})
 	return nil
 }
 
@@ -123,21 +125,6 @@ func (e *CreateCollectionExecutor) GeneratePubData() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.PubData = append(stateCache.PubData, pubData...)
-	return nil
-}
-
-func (e *CreateCollectionExecutor) UpdateTrees() error {
-	txInfo := e.txInfo
-
-	accounts := []int64{txInfo.AccountIndex, txInfo.GasAccountIndex}
-	assets := []int64{txInfo.GasFeeAssetId}
-
-	err := e.bc.StateDB().UpdateAccountTree(accounts, assets)
-	if err != nil {
-		logx.Errorf("update account tree error, err: %s", err.Error())
-		return err
-	}
-
 	return nil
 }
 

--- a/core/executor/create_pair_executor.go
+++ b/core/executor/create_pair_executor.go
@@ -32,16 +32,14 @@ func NewCreatePairExecutor(bc IBlockchain, tx *tx.Tx) (TxExecutor, error) {
 	}
 
 	return &CreatePairExecutor{
-		BaseExecutor: BaseExecutor{
-			bc:      bc,
-			tx:      tx,
-			iTxInfo: txInfo,
-		},
-		txInfo: txInfo,
+		BaseExecutor: NewBaseExecutor(bc, tx, txInfo),
+		txInfo:       txInfo,
 	}, nil
 }
 
 func (e *CreatePairExecutor) Prepare() error {
+	// Mark the tree states that would be affected in this executor.
+	e.MarkLiquidityDirty(e.txInfo.PairIndex)
 	return nil
 }
 
@@ -83,7 +81,7 @@ func (e *CreatePairExecutor) ApplyTransaction() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.PendingNewLiquidityIndexMap[txInfo.PairIndex] = statedb.StateCachePending
-	stateCache.MarkLiquidityDirty(txInfo.PairIndex)
+	e.SyncDirtyToStateCache()
 	return nil
 }
 

--- a/core/executor/create_pair_executor.go
+++ b/core/executor/create_pair_executor.go
@@ -81,8 +81,7 @@ func (e *CreatePairExecutor) ApplyTransaction() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.PendingNewLiquidityIndexMap[txInfo.PairIndex] = statedb.StateCachePending
-	e.SyncDirtyToStateCache()
-	return nil
+	return e.BaseExecutor.ApplyTransaction()
 }
 
 func (e *CreatePairExecutor) GeneratePubData() error {

--- a/core/executor/create_pair_executor.go
+++ b/core/executor/create_pair_executor.go
@@ -83,6 +83,7 @@ func (e *CreatePairExecutor) ApplyTransaction() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.PendingNewLiquidityIndexMap[txInfo.PairIndex] = statedb.StateCachePending
+	stateCache.MarkLiquidityDirty(txInfo.PairIndex)
 	return nil
 }
 
@@ -112,12 +113,6 @@ func (e *CreatePairExecutor) GeneratePubData() error {
 	stateCache.PubDataOffset = append(stateCache.PubDataOffset, uint32(len(stateCache.PubData)))
 	stateCache.PubData = append(stateCache.PubData, pubData...)
 	return nil
-}
-
-func (e *CreatePairExecutor) UpdateTrees() error {
-	bc := e.bc
-	txInfo := e.txInfo
-	return bc.StateDB().UpdateLiquidityTree(txInfo.PairIndex)
 }
 
 func (e *CreatePairExecutor) GetExecutedTx() (*tx.Tx, error) {

--- a/core/executor/deposit_executor.go
+++ b/core/executor/deposit_executor.go
@@ -33,12 +33,8 @@ func NewDepositExecutor(bc IBlockchain, tx *tx.Tx) (TxExecutor, error) {
 	}
 
 	return &DepositExecutor{
-		BaseExecutor: BaseExecutor{
-			bc:      bc,
-			tx:      tx,
-			iTxInfo: txInfo,
-		},
-		txInfo: txInfo,
+		BaseExecutor: NewBaseExecutor(bc, tx, txInfo),
+		txInfo:       txInfo,
 	}, nil
 }
 
@@ -65,15 +61,9 @@ func (e *DepositExecutor) Prepare() error {
 	// Set the right account index.
 	txInfo.AccountIndex = account.AccountIndex
 
-	accounts := []int64{txInfo.AccountIndex}
-	assets := []int64{txInfo.AssetId}
-	err = e.bc.StateDB().PrepareAccountsAndAssets(accounts, assets)
-	if err != nil {
-		logx.Errorf("prepare accounts and assets failed: %s", err.Error())
-		return err
-	}
-
-	return nil
+	// Mark the tree states that would be affected in this executor.
+	e.MarkAccountAssetsDirty(txInfo.AccountIndex, []int64{txInfo.AssetId})
+	return e.BaseExecutor.Prepare()
 }
 
 func (e *DepositExecutor) VerifyInputs() error {
@@ -95,7 +85,7 @@ func (e *DepositExecutor) ApplyTransaction() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.PendingUpdateAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
-	stateCache.MarkAccountAssetsDirty(txInfo.AccountIndex, []int64{txInfo.AssetId})
+	e.SyncDirtyToStateCache()
 	return nil
 }
 

--- a/core/executor/deposit_executor.go
+++ b/core/executor/deposit_executor.go
@@ -85,8 +85,7 @@ func (e *DepositExecutor) ApplyTransaction() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.PendingUpdateAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
-	e.SyncDirtyToStateCache()
-	return nil
+	return e.BaseExecutor.ApplyTransaction()
 }
 
 func (e *DepositExecutor) GeneratePubData() error {

--- a/core/executor/deposit_executor.go
+++ b/core/executor/deposit_executor.go
@@ -95,6 +95,7 @@ func (e *DepositExecutor) ApplyTransaction() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.PendingUpdateAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
+	stateCache.MarkAccountAssetsDirty(txInfo.AccountIndex, []int64{txInfo.AssetId})
 	return nil
 }
 
@@ -121,14 +122,6 @@ func (e *DepositExecutor) GeneratePubData() error {
 	stateCache.PubDataOffset = append(stateCache.PubDataOffset, uint32(len(stateCache.PubData)))
 	stateCache.PubData = append(stateCache.PubData, pubData...)
 	return nil
-}
-
-func (e *DepositExecutor) UpdateTrees() error {
-	bc := e.bc
-	txInfo := e.txInfo
-	accounts := []int64{txInfo.AccountIndex}
-	assets := []int64{txInfo.AssetId}
-	return bc.StateDB().UpdateAccountTree(accounts, assets)
 }
 
 func (e *DepositExecutor) GetExecutedTx() (*tx.Tx, error) {

--- a/core/executor/deposit_nft_executor.go
+++ b/core/executor/deposit_nft_executor.go
@@ -120,8 +120,7 @@ func (e *DepositNftExecutor) ApplyTransaction() error {
 	} else {
 		stateCache.PendingUpdateNftIndexMap[txInfo.NftIndex] = statedb.StateCachePending
 	}
-	e.SyncDirtyToStateCache()
-	return nil
+	return e.BaseExecutor.ApplyTransaction()
 }
 
 func (e *DepositNftExecutor) GeneratePubData() error {

--- a/core/executor/deposit_nft_executor.go
+++ b/core/executor/deposit_nft_executor.go
@@ -129,7 +129,7 @@ func (e *DepositNftExecutor) ApplyTransaction() error {
 	} else {
 		stateCache.PendingUpdateNftIndexMap[txInfo.NftIndex] = statedb.StateCachePending
 	}
-
+	stateCache.MarkNftDirty(txInfo.NftIndex)
 	return nil
 }
 
@@ -162,13 +162,6 @@ func (e *DepositNftExecutor) GeneratePubData() error {
 	stateCache.PubDataOffset = append(stateCache.PubDataOffset, uint32(len(stateCache.PubData)))
 	stateCache.PubData = append(stateCache.PubData, pubData...)
 	return nil
-}
-
-func (e *DepositNftExecutor) UpdateTrees() error {
-	bc := e.bc
-	txInfo := e.txInfo
-
-	return bc.StateDB().UpdateNftTree(txInfo.NftIndex)
 }
 
 func (e *DepositNftExecutor) GetExecutedTx() (*tx.Tx, error) {

--- a/core/executor/executor.go
+++ b/core/executor/executor.go
@@ -23,7 +23,6 @@ type TxExecutor interface {
 	VerifyInputs() error
 	ApplyTransaction() error
 	GeneratePubData() error
-	UpdateTrees() error
 	GetExecutedTx() (*tx.Tx, error)
 	GenerateTxDetails() ([]*tx.TxDetail, error)
 	GenerateMempoolTx() (*mempool.MempoolTx, error)

--- a/core/executor/full_exit_executor.go
+++ b/core/executor/full_exit_executor.go
@@ -93,6 +93,7 @@ func (e *FullExitExecutor) ApplyTransaction() error {
 	if txInfo.AssetAmount.Cmp(types.ZeroBigInt) != 0 {
 		stateCache := e.bc.StateDB()
 		stateCache.PendingUpdateAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
+		stateCache.MarkAccountAssetsDirty(txInfo.AccountIndex, []int64{txInfo.AssetId})
 	}
 	return nil
 }
@@ -122,14 +123,6 @@ func (e *FullExitExecutor) GeneratePubData() error {
 	stateCache.PendingOnChainOperationsHash = common2.ConcatKeccakHash(stateCache.PendingOnChainOperationsHash, pubData)
 	stateCache.PubData = append(stateCache.PubData, pubData...)
 	return nil
-}
-
-func (e *FullExitExecutor) UpdateTrees() error {
-	bc := e.bc
-	txInfo := e.txInfo
-	accounts := []int64{txInfo.AccountIndex}
-	assets := []int64{txInfo.AssetId}
-	return bc.StateDB().UpdateAccountTree(accounts, assets)
 }
 
 func (e *FullExitExecutor) GetExecutedTx() (*tx.Tx, error) {

--- a/core/executor/full_exit_executor.go
+++ b/core/executor/full_exit_executor.go
@@ -87,9 +87,8 @@ func (e *FullExitExecutor) ApplyTransaction() error {
 	if txInfo.AssetAmount.Cmp(types.ZeroBigInt) != 0 {
 		stateCache := e.bc.StateDB()
 		stateCache.PendingUpdateAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
-		e.SyncDirtyToStateCache()
 	}
-	return nil
+	return e.BaseExecutor.ApplyTransaction()
 }
 
 func (e *FullExitExecutor) GeneratePubData() error {

--- a/core/executor/full_exit_executor.go
+++ b/core/executor/full_exit_executor.go
@@ -33,12 +33,8 @@ func NewFullExitExecutor(bc IBlockchain, tx *tx.Tx) (TxExecutor, error) {
 	}
 
 	return &FullExitExecutor{
-		BaseExecutor: BaseExecutor{
-			bc:      bc,
-			tx:      tx,
-			iTxInfo: txInfo,
-		},
-		txInfo: txInfo,
+		BaseExecutor: NewBaseExecutor(bc, tx, txInfo),
+		txInfo:       txInfo,
 	}, nil
 }
 
@@ -65,17 +61,15 @@ func (e *FullExitExecutor) Prepare() error {
 	// Set the right account index.
 	txInfo.AccountIndex = account.AccountIndex
 
-	accounts := []int64{txInfo.AccountIndex}
-	assets := []int64{txInfo.AssetId}
-	err = e.bc.StateDB().PrepareAccountsAndAssets(accounts, assets)
+	// Mark the tree states that would be affected in this executor.
+	e.MarkAccountAssetsDirty(txInfo.AccountIndex, []int64{txInfo.AssetId})
+	err = e.BaseExecutor.Prepare()
 	if err != nil {
-		logx.Errorf("prepare accounts and assets failed: %s", err.Error())
-		return errors.New("internal error")
+		return err
 	}
 
 	// Set the right asset amount.
 	txInfo.AssetAmount = bc.StateDB().AccountMap[txInfo.AccountIndex].AssetInfo[txInfo.AssetId].Balance
-
 	return nil
 }
 
@@ -93,7 +87,7 @@ func (e *FullExitExecutor) ApplyTransaction() error {
 	if txInfo.AssetAmount.Cmp(types.ZeroBigInt) != 0 {
 		stateCache := e.bc.StateDB()
 		stateCache.PendingUpdateAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
-		stateCache.MarkAccountAssetsDirty(txInfo.AccountIndex, []int64{txInfo.AssetId})
+		e.SyncDirtyToStateCache()
 	}
 	return nil
 }

--- a/core/executor/full_exit_nft_executor.go
+++ b/core/executor/full_exit_nft_executor.go
@@ -162,6 +162,7 @@ func (e *FullExitNftExecutor) ApplyTransaction() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.PendingUpdateNftIndexMap[txInfo.NftIndex] = statedb.StateCachePending
+	stateCache.MarkNftDirty(txInfo.NftIndex)
 	return nil
 }
 
@@ -195,18 +196,6 @@ func (e *FullExitNftExecutor) GeneratePubData() error {
 	stateCache.PendingOnChainOperationsHash = common2.ConcatKeccakHash(stateCache.PendingOnChainOperationsHash, pubData)
 	stateCache.PubData = append(stateCache.PubData, pubData...)
 	return nil
-}
-
-func (e *FullExitNftExecutor) UpdateTrees() error {
-	bc := e.bc
-	txInfo := e.txInfo
-
-	if bc.StateDB().NftMap[txInfo.NftIndex] == nil {
-		// Do nothing when nft doesn't exist.
-		return nil
-	}
-
-	return bc.StateDB().UpdateNftTree(txInfo.NftIndex)
 }
 
 func (e *FullExitNftExecutor) GetExecutedTx() (*tx.Tx, error) {

--- a/core/executor/full_exit_nft_executor.go
+++ b/core/executor/full_exit_nft_executor.go
@@ -158,8 +158,7 @@ func (e *FullExitNftExecutor) ApplyTransaction() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.PendingUpdateNftIndexMap[txInfo.NftIndex] = statedb.StateCachePending
-	e.SyncDirtyToStateCache()
-	return nil
+	return e.BaseExecutor.ApplyTransaction()
 }
 
 func (e *FullExitNftExecutor) GeneratePubData() error {

--- a/core/executor/mint_nft_executor.go
+++ b/core/executor/mint_nft_executor.go
@@ -112,6 +112,9 @@ func (e *MintNftExecutor) ApplyTransaction() error {
 	stateCache.PendingUpdateAccountIndexMap[txInfo.CreatorAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
 	stateCache.PendingNewNftIndexMap[txInfo.NftIndex] = statedb.StateCachePending
+	stateCache.MarkAccountAssetsDirty(txInfo.CreatorAccountIndex, []int64{txInfo.GasFeeAssetId})
+	stateCache.MarkAccountAssetsDirty(txInfo.GasAccountIndex, []int64{txInfo.GasFeeAssetId})
+	stateCache.MarkNftDirty(txInfo.NftIndex)
 	return nil
 }
 
@@ -146,26 +149,6 @@ func (e *MintNftExecutor) GeneratePubData() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.PubData = append(stateCache.PubData, pubData...)
-	return nil
-}
-
-func (e *MintNftExecutor) UpdateTrees() error {
-	txInfo := e.txInfo
-
-	accounts := []int64{txInfo.CreatorAccountIndex, txInfo.ToAccountIndex, txInfo.GasAccountIndex}
-	assets := []int64{txInfo.GasFeeAssetId}
-
-	err := e.bc.StateDB().UpdateAccountTree(accounts, assets)
-	if err != nil {
-		logx.Errorf("update account tree error, err: %s", err.Error())
-		return err
-	}
-
-	err = e.bc.StateDB().UpdateNftTree(txInfo.NftIndex)
-	if err != nil {
-		logx.Errorf("update nft tree error, err: %s", err.Error())
-		return err
-	}
 	return nil
 }
 

--- a/core/executor/mint_nft_executor.go
+++ b/core/executor/mint_nft_executor.go
@@ -105,8 +105,7 @@ func (e *MintNftExecutor) ApplyTransaction() error {
 	stateCache.PendingUpdateAccountIndexMap[txInfo.CreatorAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
 	stateCache.PendingNewNftIndexMap[txInfo.NftIndex] = statedb.StateCachePending
-	e.SyncDirtyToStateCache()
-	return nil
+	return e.BaseExecutor.ApplyTransaction()
 }
 
 func (e *MintNftExecutor) GeneratePubData() error {

--- a/core/executor/register_zns_executor.go
+++ b/core/executor/register_zns_executor.go
@@ -34,16 +34,14 @@ func NewRegisterZnsExecutor(bc IBlockchain, tx *tx.Tx) (TxExecutor, error) {
 	}
 
 	return &RegisterZnsExecutor{
-		BaseExecutor: BaseExecutor{
-			bc:      bc,
-			tx:      tx,
-			iTxInfo: txInfo,
-		},
-		txInfo: txInfo,
+		BaseExecutor: NewBaseExecutor(bc, tx, txInfo),
+		txInfo:       txInfo,
 	}, nil
 }
 
 func (e *RegisterZnsExecutor) Prepare() error {
+	// Mark the tree states that would be affected in this executor.
+	e.MarkAccountAssetsDirty(e.txInfo.AccountIndex, []int64{})
 	return nil
 }
 
@@ -100,7 +98,7 @@ func (e *RegisterZnsExecutor) ApplyTransaction() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.PendingNewAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
-	stateCache.MarkAccountAssetsDirty(txInfo.AccountIndex, []int64{})
+	e.SyncDirtyToStateCache()
 	return nil
 }
 

--- a/core/executor/register_zns_executor.go
+++ b/core/executor/register_zns_executor.go
@@ -98,8 +98,7 @@ func (e *RegisterZnsExecutor) ApplyTransaction() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.PendingNewAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
-	e.SyncDirtyToStateCache()
-	return nil
+	return e.BaseExecutor.ApplyTransaction()
 }
 
 func (e *RegisterZnsExecutor) GeneratePubData() error {

--- a/core/executor/remove_liquidity_executor.go
+++ b/core/executor/remove_liquidity_executor.go
@@ -181,8 +181,7 @@ func (e *RemoveLiquidityExecutor) ApplyTransaction() error {
 	stateCache.PendingUpdateAccountIndexMap[treasuryAccount.AccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateLiquidityIndexMap[txInfo.PairIndex] = statedb.StateCachePending
-	e.SyncDirtyToStateCache()
-	return nil
+	return e.BaseExecutor.ApplyTransaction()
 }
 
 func (e *RemoveLiquidityExecutor) GeneratePubData() error {

--- a/core/executor/swap_executor.go
+++ b/core/executor/swap_executor.go
@@ -153,8 +153,7 @@ func (e *SwapExecutor) ApplyTransaction() error {
 	stateCache.PendingUpdateAccountIndexMap[txInfo.FromAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateLiquidityIndexMap[txInfo.PairIndex] = statedb.StateCachePending
-	e.SyncDirtyToStateCache()
-	return nil
+	return e.BaseExecutor.ApplyTransaction()
 }
 
 func (e *SwapExecutor) fillTxInfo() error {

--- a/core/executor/swap_executor.go
+++ b/core/executor/swap_executor.go
@@ -37,39 +37,30 @@ func NewSwapExecutor(bc IBlockchain, tx *tx.Tx) (TxExecutor, error) {
 	}
 
 	return &SwapExecutor{
-		BaseExecutor: BaseExecutor{
-			bc:      bc,
-			tx:      tx,
-			iTxInfo: txInfo,
-		},
-		txInfo: txInfo,
+		BaseExecutor: NewBaseExecutor(bc, tx, txInfo),
+		txInfo:       txInfo,
 	}, nil
 }
 
 func (e *SwapExecutor) Prepare() error {
 	txInfo := e.txInfo
 
-	accounts := []int64{txInfo.FromAccountIndex, txInfo.GasAccountIndex}
-	assets := []int64{txInfo.AssetAId, txInfo.AssetBId, txInfo.PairIndex, txInfo.GasFeeAssetId}
-	err := e.bc.StateDB().PrepareAccountsAndAssets(accounts, assets)
-	if err != nil {
-		logx.Errorf("prepare accounts and assets failed: %s", err.Error())
-		return errors.New("internal error")
-	}
-
-	err = e.bc.StateDB().PrepareLiquidity(txInfo.PairIndex)
+	err := e.bc.StateDB().PrepareLiquidity(txInfo.PairIndex)
 	if err != nil {
 		logx.Errorf("prepare liquidity failed: %s", err.Error())
 		return errors.New("internal error")
 	}
 
-	// check the other restrictions
-	err = e.fillTxInfo()
+	// Mark the tree states that would be affected in this executor.
+	e.MarkLiquidityDirty(txInfo.PairIndex)
+	e.MarkAccountAssetsDirty(txInfo.FromAccountIndex, []int64{txInfo.GasFeeAssetId, txInfo.AssetAId, txInfo.AssetBId})
+	e.MarkAccountAssetsDirty(txInfo.GasAccountIndex, []int64{txInfo.GasFeeAssetId})
+	err = e.BaseExecutor.Prepare()
 	if err != nil {
 		return err
 	}
 
-	return nil
+	return e.fillTxInfo()
 }
 
 func (e *SwapExecutor) VerifyInputs() error {
@@ -162,9 +153,7 @@ func (e *SwapExecutor) ApplyTransaction() error {
 	stateCache.PendingUpdateAccountIndexMap[txInfo.FromAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateLiquidityIndexMap[txInfo.PairIndex] = statedb.StateCachePending
-	stateCache.MarkAccountAssetsDirty(txInfo.FromAccountIndex, []int64{txInfo.GasFeeAssetId, txInfo.AssetAId, txInfo.AssetBId})
-	stateCache.MarkAccountAssetsDirty(txInfo.GasAccountIndex, []int64{txInfo.GasFeeAssetId})
-	stateCache.MarkLiquidityDirty(txInfo.PairIndex)
+	e.SyncDirtyToStateCache()
 	return nil
 }
 

--- a/core/executor/transfer_executor.go
+++ b/core/executor/transfer_executor.go
@@ -104,6 +104,9 @@ func (e *TransferExecutor) ApplyTransaction() error {
 	stateCache.PendingUpdateAccountIndexMap[txInfo.FromAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.ToAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
+	stateCache.MarkAccountAssetsDirty(txInfo.FromAccountIndex, []int64{txInfo.GasFeeAssetId, txInfo.AssetId})
+	stateCache.MarkAccountAssetsDirty(txInfo.ToAccountIndex, []int64{txInfo.AssetId})
+	stateCache.MarkAccountAssetsDirty(txInfo.GasAccountIndex, []int64{txInfo.GasFeeAssetId})
 	return nil
 }
 
@@ -139,14 +142,6 @@ func (e *TransferExecutor) GeneratePubData() error {
 	stateCache := e.bc.StateDB()
 	stateCache.PubData = append(stateCache.PubData, pubData...)
 	return nil
-}
-
-func (e *TransferExecutor) UpdateTrees() error {
-	bc := e.bc
-	txInfo := e.txInfo
-	accounts := []int64{txInfo.FromAccountIndex, txInfo.ToAccountIndex, txInfo.GasAccountIndex}
-	assets := []int64{txInfo.AssetId, txInfo.GasFeeAssetId}
-	return bc.StateDB().UpdateAccountTree(accounts, assets)
 }
 
 func (e *TransferExecutor) GetExecutedTx() (*tx.Tx, error) {

--- a/core/executor/transfer_executor.go
+++ b/core/executor/transfer_executor.go
@@ -96,8 +96,7 @@ func (e *TransferExecutor) ApplyTransaction() error {
 	stateCache.PendingUpdateAccountIndexMap[txInfo.FromAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.ToAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
-	e.SyncDirtyToStateCache()
-	return nil
+	return e.BaseExecutor.ApplyTransaction()
 }
 
 func (e *TransferExecutor) GeneratePubData() error {

--- a/core/executor/transfer_nft_executor.go
+++ b/core/executor/transfer_nft_executor.go
@@ -50,6 +50,7 @@ func (e *TransferNftExecutor) Prepare() error {
 	// Mark the tree states that would be affected in this executor.
 	e.MarkNftDirty(txInfo.NftIndex)
 	e.MarkAccountAssetsDirty(txInfo.FromAccountIndex, []int64{txInfo.GasFeeAssetId})
+	e.MarkAccountAssetsDirty(txInfo.ToAccountIndex, []int64{})
 	e.MarkAccountAssetsDirty(txInfo.GasAccountIndex, []int64{txInfo.GasFeeAssetId})
 	return e.BaseExecutor.Prepare()
 }

--- a/core/executor/transfer_nft_executor.go
+++ b/core/executor/transfer_nft_executor.go
@@ -97,8 +97,7 @@ func (e *TransferNftExecutor) ApplyTransaction() error {
 	stateCache.PendingUpdateAccountIndexMap[txInfo.FromAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateNftIndexMap[txInfo.NftIndex] = statedb.StateCachePending
-	e.SyncDirtyToStateCache()
-	return nil
+	return e.BaseExecutor.ApplyTransaction()
 }
 
 func (e *TransferNftExecutor) GeneratePubData() error {

--- a/core/executor/transfer_nft_executor.go
+++ b/core/executor/transfer_nft_executor.go
@@ -105,6 +105,9 @@ func (e *TransferNftExecutor) ApplyTransaction() error {
 	stateCache.PendingUpdateAccountIndexMap[txInfo.FromAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateNftIndexMap[txInfo.NftIndex] = statedb.StateCachePending
+	stateCache.MarkAccountAssetsDirty(txInfo.FromAccountIndex, []int64{txInfo.GasFeeAssetId})
+	stateCache.MarkAccountAssetsDirty(txInfo.GasAccountIndex, []int64{txInfo.GasFeeAssetId})
+	stateCache.MarkNftDirty(txInfo.NftIndex)
 	return nil
 }
 
@@ -135,26 +138,6 @@ func (e *TransferNftExecutor) GeneratePubData() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.PubData = append(stateCache.PubData, pubData...)
-	return nil
-}
-
-func (e *TransferNftExecutor) UpdateTrees() error {
-	txInfo := e.txInfo
-
-	accounts := []int64{txInfo.FromAccountIndex, txInfo.ToAccountIndex, txInfo.GasAccountIndex}
-	assets := []int64{txInfo.GasFeeAssetId}
-
-	err := e.bc.StateDB().UpdateAccountTree(accounts, assets)
-	if err != nil {
-		logx.Errorf("update account tree error, err: %s", err.Error())
-		return err
-	}
-
-	err = e.bc.StateDB().UpdateNftTree(txInfo.NftIndex)
-	if err != nil {
-		logx.Errorf("update nft tree error, err: %s", err.Error())
-		return err
-	}
 	return nil
 }
 

--- a/core/executor/update_pair_rate_executor.go
+++ b/core/executor/update_pair_rate_executor.go
@@ -76,6 +76,7 @@ func (e *UpdatePairRateExecutor) ApplyTransaction() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.PendingUpdateLiquidityIndexMap[txInfo.PairIndex] = statedb.StateCachePending
+	stateCache.MarkLiquidityDirty(txInfo.PairIndex)
 	return nil
 }
 
@@ -103,12 +104,6 @@ func (e *UpdatePairRateExecutor) GeneratePubData() error {
 	stateCache.PubDataOffset = append(stateCache.PubDataOffset, uint32(len(stateCache.PubData)))
 	stateCache.PubData = append(stateCache.PubData, pubData...)
 	return nil
-}
-
-func (e *UpdatePairRateExecutor) UpdateTrees() error {
-	bc := e.bc
-	txInfo := e.txInfo
-	return bc.StateDB().UpdateLiquidityTree(txInfo.PairIndex)
 }
 
 func (e *UpdatePairRateExecutor) GetExecutedTx() (*tx.Tx, error) {

--- a/core/executor/update_pair_rate_executor.go
+++ b/core/executor/update_pair_rate_executor.go
@@ -75,8 +75,7 @@ func (e *UpdatePairRateExecutor) ApplyTransaction() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.PendingUpdateLiquidityIndexMap[txInfo.PairIndex] = statedb.StateCachePending
-	e.SyncDirtyToStateCache()
-	return nil
+	return e.BaseExecutor.ApplyTransaction()
 }
 
 func (e *UpdatePairRateExecutor) GeneratePubData() error {

--- a/core/executor/withdraw_executor.go
+++ b/core/executor/withdraw_executor.go
@@ -98,7 +98,8 @@ func (e *WithdrawExecutor) ApplyTransaction() error {
 	stateCache := e.bc.StateDB()
 	stateCache.PendingUpdateAccountIndexMap[txInfo.FromAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
-
+	stateCache.MarkAccountAssetsDirty(txInfo.FromAccountIndex, []int64{txInfo.GasFeeAssetId, txInfo.AssetId})
+	stateCache.MarkAccountAssetsDirty(txInfo.GasAccountIndex, []int64{txInfo.GasFeeAssetId})
 	return nil
 }
 
@@ -136,21 +137,6 @@ func (e *WithdrawExecutor) GeneratePubData() error {
 	stateCache.PendingOnChainOperationsPubData = append(stateCache.PendingOnChainOperationsPubData, pubData)
 	stateCache.PendingOnChainOperationsHash = common2.ConcatKeccakHash(stateCache.PendingOnChainOperationsHash, pubData)
 	stateCache.PubData = append(stateCache.PubData, pubData...)
-	return nil
-}
-
-func (e *WithdrawExecutor) UpdateTrees() error {
-	txInfo := e.txInfo
-
-	accounts := []int64{txInfo.FromAccountIndex, txInfo.GasAccountIndex}
-	assets := []int64{txInfo.AssetId, txInfo.GasFeeAssetId}
-
-	err := e.bc.StateDB().UpdateAccountTree(accounts, assets)
-	if err != nil {
-		logx.Errorf("update account tree error, err: %s", err.Error())
-		return err
-	}
-
 	return nil
 }
 

--- a/core/executor/withdraw_executor.go
+++ b/core/executor/withdraw_executor.go
@@ -89,8 +89,7 @@ func (e *WithdrawExecutor) ApplyTransaction() error {
 	stateCache := e.bc.StateDB()
 	stateCache.PendingUpdateAccountIndexMap[txInfo.FromAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
-	e.SyncDirtyToStateCache()
-	return nil
+	return e.BaseExecutor.ApplyTransaction()
 }
 
 func (e *WithdrawExecutor) GeneratePubData() error {

--- a/core/executor/withdraw_executor.go
+++ b/core/executor/withdraw_executor.go
@@ -33,27 +33,18 @@ func NewWithdrawExecutor(bc IBlockchain, tx *tx.Tx) (TxExecutor, error) {
 	}
 
 	return &WithdrawExecutor{
-		BaseExecutor: BaseExecutor{
-			bc:      bc,
-			tx:      tx,
-			iTxInfo: txInfo,
-		},
-		txInfo: txInfo,
+		BaseExecutor: NewBaseExecutor(bc, tx, txInfo),
+		txInfo:       txInfo,
 	}, nil
 }
 
 func (e *WithdrawExecutor) Prepare() error {
 	txInfo := e.txInfo
 
-	accounts := []int64{txInfo.FromAccountIndex, txInfo.GasAccountIndex}
-	assets := []int64{txInfo.AssetId, txInfo.GasFeeAssetId}
-	err := e.bc.StateDB().PrepareAccountsAndAssets(accounts, assets)
-	if err != nil {
-		logx.Errorf("prepare accounts and assets failed: %s", err.Error())
-		return err
-	}
-
-	return nil
+	// Mark the tree states that would be affected in this executor.
+	e.MarkAccountAssetsDirty(txInfo.FromAccountIndex, []int64{txInfo.GasFeeAssetId, txInfo.AssetId})
+	e.MarkAccountAssetsDirty(txInfo.GasAccountIndex, []int64{txInfo.GasFeeAssetId})
+	return e.BaseExecutor.Prepare()
 }
 
 func (e *WithdrawExecutor) VerifyInputs() error {
@@ -98,8 +89,7 @@ func (e *WithdrawExecutor) ApplyTransaction() error {
 	stateCache := e.bc.StateDB()
 	stateCache.PendingUpdateAccountIndexMap[txInfo.FromAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
-	stateCache.MarkAccountAssetsDirty(txInfo.FromAccountIndex, []int64{txInfo.GasFeeAssetId, txInfo.AssetId})
-	stateCache.MarkAccountAssetsDirty(txInfo.GasAccountIndex, []int64{txInfo.GasFeeAssetId})
+	e.SyncDirtyToStateCache()
 	return nil
 }
 

--- a/core/executor/withdraw_nft_executor.go
+++ b/core/executor/withdraw_nft_executor.go
@@ -126,7 +126,9 @@ func (e *WithdrawNftExecutor) ApplyTransaction() error {
 	stateCache.PendingUpdateAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateNftIndexMap[txInfo.NftIndex] = statedb.StateCachePending
-
+	stateCache.MarkAccountAssetsDirty(txInfo.AccountIndex, []int64{txInfo.GasFeeAssetId})
+	stateCache.MarkAccountAssetsDirty(txInfo.GasAccountIndex, []int64{txInfo.GasFeeAssetId})
+	stateCache.MarkNftDirty(txInfo.NftIndex)
 	return nil
 }
 
@@ -169,26 +171,6 @@ func (e *WithdrawNftExecutor) GeneratePubData() error {
 	stateCache.PendingOnChainOperationsPubData = append(stateCache.PendingOnChainOperationsPubData, pubData)
 	stateCache.PendingOnChainOperationsHash = common2.ConcatKeccakHash(stateCache.PendingOnChainOperationsHash, pubData)
 	stateCache.PubData = append(stateCache.PubData, pubData...)
-	return nil
-}
-
-func (e *WithdrawNftExecutor) UpdateTrees() error {
-	txInfo := e.txInfo
-
-	accounts := []int64{txInfo.AccountIndex, txInfo.GasAccountIndex}
-	assets := []int64{txInfo.GasFeeAssetId}
-
-	err := e.bc.StateDB().UpdateAccountTree(accounts, assets)
-	if err != nil {
-		logx.Errorf("update account tree error, err: %s", err.Error())
-		return err
-	}
-
-	err = e.bc.StateDB().UpdateNftTree(txInfo.NftIndex)
-	if err != nil {
-		logx.Errorf("update nft tree error, err: %s", err.Error())
-		return err
-	}
 	return nil
 }
 

--- a/core/executor/withdraw_nft_executor.go
+++ b/core/executor/withdraw_nft_executor.go
@@ -63,7 +63,7 @@ func (e *WithdrawNftExecutor) Prepare() error {
 
 	// Set the right details to tx info.
 	txInfo.CreatorAccountIndex = nftInfo.CreatorAccountIndex
-	txInfo.CreatorAccountNameHash = common.FromHex(types.NilAccountNameHash)
+	txInfo.CreatorAccountNameHash = common.FromHex(types.EmptyAccountNameHash)
 	if nftInfo.CreatorAccountIndex != types.NilAccountIndex {
 		creatorAccount := e.bc.StateDB().AccountMap[nftInfo.CreatorAccountIndex]
 		txInfo.CreatorAccountNameHash = common.FromHex(creatorAccount.AccountNameHash)
@@ -128,8 +128,7 @@ func (e *WithdrawNftExecutor) ApplyTransaction() error {
 	stateCache.PendingUpdateAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateNftIndexMap[txInfo.NftIndex] = statedb.StateCachePending
-	e.SyncDirtyToStateCache()
-	return nil
+	return e.BaseExecutor.ApplyTransaction()
 }
 
 func (e *WithdrawNftExecutor) GeneratePubData() error {

--- a/core/statedb/state_cache.go
+++ b/core/statedb/state_cache.go
@@ -72,8 +72,7 @@ func (c *StateCache) MarkAccountAssetsDirty(accountIndex int64, assets []int64) 
 		return
 	}
 
-	_, ok := c.DirtyAccountsAndAssetsMap[accountIndex]
-	if !ok {
+	if _, ok := c.DirtyAccountsAndAssetsMap[accountIndex]; !ok {
 		c.DirtyAccountsAndAssetsMap[accountIndex] = make(map[int64]bool, 0)
 	}
 

--- a/core/statedb/statedb.go
+++ b/core/statedb/statedb.go
@@ -358,8 +358,8 @@ func (s *StateDB) DeepCopyAccounts(accountIds []int64) (map[int64]*types.Account
 	return accounts, nil
 }
 
-func (s *StateDB) PrepareAccountsAndAssets(accounts []int64, assets []int64) error {
-	for _, accountIndex := range accounts {
+func (s *StateDB) PrepareAccountsAndAssets(accountAssetsMap map[int64]map[int64]bool) error {
+	for accountIndex, assets := range accountAssetsMap {
 		if s.dryRun {
 			account := &account.Account{}
 			redisAccount, err := s.redisCache.Get(context.Background(), dbcache.AccountKeyByIndex(accountIndex), account)
@@ -384,7 +384,7 @@ func (s *StateDB) PrepareAccountsAndAssets(accounts []int64, assets []int64) err
 		if s.AccountMap[accountIndex].AssetInfo == nil {
 			s.AccountMap[accountIndex].AssetInfo = make(map[int64]*types.AccountAsset)
 		}
-		for _, assetId := range assets {
+		for assetId := range assets {
 			if s.AccountMap[accountIndex].AssetInfo[assetId] == nil {
 				s.AccountMap[accountIndex].AssetInfo[assetId] = &types.AccountAsset{
 					AssetId:                  assetId,

--- a/dao/tx/tx.go
+++ b/dao/tx/tx.go
@@ -63,7 +63,6 @@ type (
 		TxStatus      int64
 		BlockHeight   int64 `gorm:"index"`
 		BlockId       int64 `gorm:"index"`
-		StateRoot     string
 		NftIndex      int64
 		PairIndex     int64
 		CollectionId  int64

--- a/service/apiserver/internal/logic/utils/converter.go
+++ b/service/apiserver/internal/logic/utils/converter.go
@@ -15,7 +15,6 @@ func DbtxTx(tx *tx.Tx) *types.Tx {
 		Status:        tx.TxStatus,
 		Index:         tx.TxIndex,
 		BlockHeight:   tx.BlockHeight,
-		StateRoot:     tx.StateRoot,
 		NftIndex:      tx.NftIndex,
 		PairIndex:     tx.PairIndex,
 		CollectionId:  tx.CollectionId,


### PR DESCRIPTION
### Description

1. This PR introduces intermediating state root when committing a new block, and deletes the update tree after each transaction has been applied.
2. This PR makes the preparation for the related accounts and assets precise, with no redundant initialization.

### Rationale

1. In the current implementation, tx executors will update state trees after each tx has been applied. Actually, we need to update the state tree only when we commit a block, there is no need to compute the state root of each transaction in the committer process. This PR can avoid lots of unnecessary computing of state root, and improve the efficiency of the committer.
2. When we prepare the related accounts and assets, the assets of some accounts may doesn't affected, so we should delete the unnecessary initialization.

### Example

NA

### Changes

Notable changes:
* Delete update tree for each tx executor
* Make prepare precise