### PR TITLE
CI(integration): add label option to skip integration test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -17,6 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: deploy new zkbnb on runner
+        if: !contains(github.event.pull_request.body, '/skip-integration-test')
         run: |
           echo 'fetch zkbnb repo'
           export PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')


### PR DESCRIPTION
### Description

add label option to skip integration test
- /skip-integration-test

### Rationale

for the pr do not require an integration test to be triggered

### Example

add `/skip-integration-test` in pr desc

### Changes

Notable changes:
* add label option to skip integration test
