### PR TITLE
statedb: refactor cache layer

### DIFF
--- a/core/block_processor.go
+++ b/core/block_processor.go
@@ -6,6 +6,7 @@ import (
 	"github.com/bnb-chain/zkbnb/core/executor"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
+	"github.com/zeromicro/go-zero/core/logx"
 )
 
 type Processor interface {
@@ -80,7 +81,8 @@ func (p *APIProcessor) Process(tx *tx.Tx) error {
 
 	err = executor.Prepare()
 	if err != nil {
-		return err
+		logx.Error("fail to prepare:", err)
+		return types.AppErrInternal
 	}
 	err = executor.VerifyInputs()
 	if err != nil {

--- a/core/executor/add_liquidity_executor.go
+++ b/core/executor/add_liquidity_executor.go
@@ -12,7 +12,6 @@ import (
 	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	common2 "github.com/bnb-chain/zkbnb/common"
 	"github.com/bnb-chain/zkbnb/common/chain"
-	"github.com/bnb-chain/zkbnb/core/statedb"
 	"github.com/bnb-chain/zkbnb/dao/liquidity"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
@@ -177,10 +176,6 @@ func (e *AddLiquidityExecutor) ApplyTransaction() error {
 		TreasuryAccountIndex: e.newPoolInfo.TreasuryAccountIndex,
 		TreasuryRate:         e.newPoolInfo.TreasuryRate,
 	})
-	stateCache.PendingUpdateAccountIndexMap[txInfo.FromAccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateAccountIndexMap[treasuryAccount.AccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateLiquidityIndexMap[txInfo.PairIndex] = statedb.StateCachePending
 	return e.BaseExecutor.ApplyTransaction()
 }
 

--- a/core/executor/atomic_match_executor.go
+++ b/core/executor/atomic_match_executor.go
@@ -11,7 +11,6 @@ import (
 	"github.com/bnb-chain/zkbnb-crypto/ffmath"
 	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	common2 "github.com/bnb-chain/zkbnb/common"
-	"github.com/bnb-chain/zkbnb/core/statedb"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
 )
@@ -217,12 +216,6 @@ func (e *AtomicMatchExecutor) ApplyTransaction() error {
 	stateCache.SetPendingUpdateAccount(gasAccount.AccountIndex, gasAccount)
 	stateCache.SetPendingUpdateAccount(creatorAccount.AccountIndex, creatorAccount)
 	stateCache.SetPendingUpdateNft(matchNft.NftIndex, matchNft)
-	stateCache.PendingUpdateAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateAccountIndexMap[txInfo.BuyOffer.AccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateAccountIndexMap[txInfo.SellOffer.AccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateAccountIndexMap[matchNft.CreatorAccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateNftIndexMap[txInfo.SellOffer.NftIndex] = statedb.StateCachePending
 	return e.BaseExecutor.ApplyTransaction()
 }
 

--- a/core/executor/base_executor.go
+++ b/core/executor/base_executor.go
@@ -87,7 +87,11 @@ func (e *BaseExecutor) VerifyInputs() error {
 			return err
 		}
 
-		err = txInfo.VerifySignature(e.bc.StateDB().AccountMap[from].PublicKey)
+		fromAccount, err := e.bc.StateDB().GetFormatAccount(from)
+		if err != nil {
+			return err
+		}
+		err = txInfo.VerifySignature(fromAccount.PublicKey)
 		if err != nil {
 			return err
 		}

--- a/core/executor/cancel_offer_executor.go
+++ b/core/executor/cancel_offer_executor.go
@@ -11,7 +11,6 @@ import (
 	"github.com/bnb-chain/zkbnb-crypto/ffmath"
 	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	common2 "github.com/bnb-chain/zkbnb/common"
-	"github.com/bnb-chain/zkbnb/core/statedb"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
 )
@@ -101,8 +100,6 @@ func (e *CancelOfferExecutor) ApplyTransaction() error {
 	stateCache := e.bc.StateDB()
 	stateCache.SetPendingUpdateAccount(fromAccount.AccountIndex, fromAccount)
 	stateCache.SetPendingUpdateAccount(gasAccount.AccountIndex, gasAccount)
-	stateCache.PendingUpdateAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
 	return e.BaseExecutor.ApplyTransaction()
 }
 

--- a/core/executor/cancel_offer_executor.go
+++ b/core/executor/cancel_offer_executor.go
@@ -53,14 +53,17 @@ func (e *CancelOfferExecutor) VerifyInputs() error {
 		return err
 	}
 
-	fromAccount := e.bc.StateDB().AccountMap[txInfo.AccountIndex]
+	fromAccount, err := e.bc.StateDB().GetFormatAccount(txInfo.AccountIndex)
+	if err != nil {
+		return err
+	}
 	if fromAccount.AssetInfo[txInfo.GasFeeAssetId].Balance.Cmp(txInfo.GasFeeAssetAmount) < 0 {
 		return errors.New("balance is not enough")
 	}
 
 	offerAssetId := txInfo.OfferId / 128
 	offerIndex := txInfo.OfferId % 128
-	offerAsset := e.bc.StateDB().AccountMap[txInfo.AccountIndex].AssetInfo[offerAssetId]
+	offerAsset := fromAccount.AssetInfo[offerAssetId]
 	if offerAsset != nil && offerAsset.OfferCanceledOrFinalized != nil {
 		xBit := offerAsset.OfferCanceledOrFinalized.Bit(int(offerIndex))
 		if xBit == 1 {
@@ -76,8 +79,14 @@ func (e *CancelOfferExecutor) ApplyTransaction() error {
 	txInfo := e.txInfo
 
 	// apply changes
-	fromAccount := bc.StateDB().AccountMap[txInfo.AccountIndex]
-	gasAccount := bc.StateDB().AccountMap[txInfo.GasAccountIndex]
+	fromAccount, err := bc.StateDB().GetFormatAccount(txInfo.AccountIndex)
+	if err != nil {
+		return err
+	}
+	gasAccount, err := bc.StateDB().GetFormatAccount(txInfo.GasAccountIndex)
+	if err != nil {
+		return err
+	}
 
 	fromAccount.AssetInfo[txInfo.GasFeeAssetId].Balance = ffmath.Sub(fromAccount.AssetInfo[txInfo.GasFeeAssetId].Balance, txInfo.GasFeeAssetAmount)
 	gasAccount.AssetInfo[txInfo.GasFeeAssetId].Balance = ffmath.Add(gasAccount.AssetInfo[txInfo.GasFeeAssetId].Balance, txInfo.GasFeeAssetAmount)
@@ -90,6 +99,8 @@ func (e *CancelOfferExecutor) ApplyTransaction() error {
 	fromAccount.AssetInfo[offerAssetId].OfferCanceledOrFinalized = nOffer
 
 	stateCache := e.bc.StateDB()
+	stateCache.SetPendingUpdateAccount(fromAccount.AccountIndex, fromAccount)
+	stateCache.SetPendingUpdateAccount(gasAccount.AccountIndex, gasAccount)
 	stateCache.PendingUpdateAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
 	return e.BaseExecutor.ApplyTransaction()

--- a/core/executor/create_collection_executor.go
+++ b/core/executor/create_collection_executor.go
@@ -12,7 +12,6 @@ import (
 	"github.com/bnb-chain/zkbnb-crypto/ffmath"
 	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	common2 "github.com/bnb-chain/zkbnb/common"
-	"github.com/bnb-chain/zkbnb/core/statedb"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
 )
@@ -97,8 +96,6 @@ func (e *CreateCollectionExecutor) ApplyTransaction() error {
 	stateCache := e.bc.StateDB()
 	stateCache.SetPendingUpdateAccount(fromAccount.AccountIndex, fromAccount)
 	stateCache.SetPendingUpdateAccount(gasAccount.AccountIndex, gasAccount)
-	stateCache.PendingUpdateAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
 	return e.BaseExecutor.ApplyTransaction()
 }
 

--- a/core/executor/create_pair_executor.go
+++ b/core/executor/create_pair_executor.go
@@ -61,7 +61,6 @@ func (e *CreatePairExecutor) VerifyInputs() error {
 }
 
 func (e *CreatePairExecutor) ApplyTransaction() error {
-	bc := e.bc
 	txInfo := e.txInfo
 
 	newLiquidity := &liquidity.Liquidity{
@@ -76,9 +75,9 @@ func (e *CreatePairExecutor) ApplyTransaction() error {
 		FeeRate:              txInfo.FeeRate,
 		TreasuryRate:         txInfo.TreasuryRate,
 	}
-	bc.StateDB().LiquidityMap[txInfo.PairIndex] = newLiquidity
 
 	stateCache := e.bc.StateDB()
+	stateCache.SetPendingNewLiquidity(txInfo.PairIndex, newLiquidity)
 	stateCache.PendingNewLiquidityIndexMap[txInfo.PairIndex] = statedb.StateCachePending
 	return e.BaseExecutor.ApplyTransaction()
 }

--- a/core/executor/create_pair_executor.go
+++ b/core/executor/create_pair_executor.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	"github.com/bnb-chain/zkbnb/common"
-	"github.com/bnb-chain/zkbnb/core/statedb"
 	"github.com/bnb-chain/zkbnb/dao/liquidity"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
@@ -51,7 +50,7 @@ func (e *CreatePairExecutor) VerifyInputs() error {
 		return errors.New("invalid pair index, already registered")
 	}
 
-	for index := range bc.StateDB().PendingNewLiquidityIndexMap {
+	for index := range bc.StateDB().PendingNewLiquidityMap {
 		if txInfo.PairIndex == index {
 			return errors.New("invalid pair index, already registered")
 		}
@@ -78,7 +77,6 @@ func (e *CreatePairExecutor) ApplyTransaction() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.SetPendingNewLiquidity(txInfo.PairIndex, newLiquidity)
-	stateCache.PendingNewLiquidityIndexMap[txInfo.PairIndex] = statedb.StateCachePending
 	return e.BaseExecutor.ApplyTransaction()
 }
 

--- a/core/executor/deposit_executor.go
+++ b/core/executor/deposit_executor.go
@@ -12,7 +12,6 @@ import (
 	"github.com/bnb-chain/zkbnb-crypto/ffmath"
 	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	common2 "github.com/bnb-chain/zkbnb/common"
-	"github.com/bnb-chain/zkbnb/core/statedb"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
 )
@@ -45,7 +44,7 @@ func (e *DepositExecutor) Prepare() error {
 	account, err := bc.DB().AccountModel.GetAccountByNameHash(accountNameHash)
 	if err != nil {
 		exist := false
-		for index := range bc.StateDB().PendingNewAccountIndexMap {
+		for index := range bc.StateDB().PendingNewAccountMap {
 			tempAccount, err := bc.StateDB().GetAccount(index)
 			if err != nil {
 				continue
@@ -92,7 +91,6 @@ func (e *DepositExecutor) ApplyTransaction() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.SetPendingUpdateAccount(depositAccount.AccountIndex, depositAccount)
-	stateCache.PendingUpdateAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
 	return e.BaseExecutor.ApplyTransaction()
 }
 

--- a/core/executor/deposit_executor.go
+++ b/core/executor/deposit_executor.go
@@ -12,7 +12,6 @@ import (
 	"github.com/bnb-chain/zkbnb-crypto/ffmath"
 	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	common2 "github.com/bnb-chain/zkbnb/common"
-	"github.com/bnb-chain/zkbnb/common/chain"
 	"github.com/bnb-chain/zkbnb/core/statedb"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
@@ -45,14 +44,20 @@ func (e *DepositExecutor) Prepare() error {
 	accountNameHash := common.Bytes2Hex(txInfo.AccountNameHash)
 	account, err := bc.DB().AccountModel.GetAccountByNameHash(accountNameHash)
 	if err != nil {
+		exist := false
 		for index := range bc.StateDB().PendingNewAccountIndexMap {
-			if accountNameHash == bc.StateDB().AccountMap[index].AccountNameHash {
-				account, err = chain.FromFormatAccountInfo(bc.StateDB().AccountMap[index])
+			tempAccount, err := bc.StateDB().GetAccount(index)
+			if err != nil {
+				continue
+			}
+			if accountNameHash == tempAccount.AccountNameHash {
+				account = tempAccount
+				exist = true
 				break
 			}
 		}
 
-		if err != nil {
+		if !exist {
 			return errors.New("invalid account name hash")
 		}
 	}
@@ -79,10 +84,14 @@ func (e *DepositExecutor) ApplyTransaction() error {
 	bc := e.bc
 	txInfo := e.txInfo
 
-	depositAccount := bc.StateDB().AccountMap[txInfo.AccountIndex]
+	depositAccount, err := bc.StateDB().GetFormatAccount(txInfo.AccountIndex)
+	if err != nil {
+		return err
+	}
 	depositAccount.AssetInfo[txInfo.AssetId].Balance = ffmath.Add(depositAccount.AssetInfo[txInfo.AssetId].Balance, txInfo.AssetAmount)
 
 	stateCache := e.bc.StateDB()
+	stateCache.SetPendingUpdateAccount(depositAccount.AccountIndex, depositAccount)
 	stateCache.PendingUpdateAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
 	return e.BaseExecutor.ApplyTransaction()
 }
@@ -128,7 +137,10 @@ func (e *DepositExecutor) GetExecutedTx() (*tx.Tx, error) {
 
 func (e *DepositExecutor) GenerateTxDetails() ([]*tx.TxDetail, error) {
 	txInfo := e.txInfo
-	depositAccount := e.bc.StateDB().AccountMap[txInfo.AccountIndex]
+	depositAccount, err := e.bc.StateDB().GetFormatAccount(txInfo.AccountIndex)
+	if err != nil {
+		return nil, err
+	}
 	baseBalance := depositAccount.AssetInfo[txInfo.AssetId]
 	deltaBalance := &types.AccountAsset{
 		AssetId:                  txInfo.AssetId,

--- a/core/executor/deposit_nft_executor.go
+++ b/core/executor/deposit_nft_executor.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	common2 "github.com/bnb-chain/zkbnb/common"
-	"github.com/bnb-chain/zkbnb/core/statedb"
 	"github.com/bnb-chain/zkbnb/dao/nft"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
@@ -47,7 +46,7 @@ func (e *DepositNftExecutor) Prepare() error {
 	account, err := bc.DB().AccountModel.GetAccountByNameHash(accountNameHash)
 	if err != nil {
 		exist := false
-		for index := range bc.StateDB().PendingNewAccountIndexMap {
+		for index := range bc.StateDB().PendingNewAccountMap {
 			tempAccount, err := bc.StateDB().GetAccount(index)
 			if err != nil {
 				continue
@@ -118,10 +117,8 @@ func (e *DepositNftExecutor) ApplyTransaction() error {
 	stateCache := e.bc.StateDB()
 	if e.isNewNft {
 		stateCache.SetPendingNewNft(txInfo.NftIndex, nft)
-		stateCache.PendingNewNftIndexMap[txInfo.NftIndex] = statedb.StateCachePending
 	} else {
 		stateCache.SetPendingUpdateNft(txInfo.NftIndex, nft)
-		stateCache.PendingUpdateNftIndexMap[txInfo.NftIndex] = statedb.StateCachePending
 	}
 	return e.BaseExecutor.ApplyTransaction()
 }

--- a/core/executor/deposit_nft_executor.go
+++ b/core/executor/deposit_nft_executor.go
@@ -90,8 +90,11 @@ func (e *DepositNftExecutor) VerifyInputs() error {
 	txInfo := e.txInfo
 
 	nft, err := bc.StateDB().GetNft(txInfo.NftIndex)
-	if e.isNewNft && err == nil {
-		return errors.New("invalid nft index, already exist")
+	if e.isNewNft && nft == nil {
+		return nil
+	}
+	if err != nil {
+		return err
 	}
 	if nft.NftContentHash != types.EmptyNftContentHash {
 		return errors.New("invalid nft index, already exist")

--- a/core/executor/full_exit_executor.go
+++ b/core/executor/full_exit_executor.go
@@ -12,7 +12,6 @@ import (
 	"github.com/bnb-chain/zkbnb-crypto/ffmath"
 	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	common2 "github.com/bnb-chain/zkbnb/common"
-	"github.com/bnb-chain/zkbnb/core/statedb"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
 )
@@ -45,7 +44,7 @@ func (e *FullExitExecutor) Prepare() error {
 	account, err := bc.DB().AccountModel.GetAccountByNameHash(accountNameHash)
 	if err != nil {
 		exist := false
-		for index := range bc.StateDB().PendingNewAccountIndexMap {
+		for index := range bc.StateDB().PendingNewAccountMap {
 			tempAccount, err := bc.StateDB().GetAccount(index)
 			if err != nil {
 				continue
@@ -98,7 +97,6 @@ func (e *FullExitExecutor) ApplyTransaction() error {
 	if txInfo.AssetAmount.Cmp(types.ZeroBigInt) != 0 {
 		stateCache := e.bc.StateDB()
 		stateCache.SetPendingUpdateAccount(txInfo.AccountIndex, exitAccount)
-		stateCache.PendingUpdateAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
 	}
 	return e.BaseExecutor.ApplyTransaction()
 }

--- a/core/executor/full_exit_nft_executor.go
+++ b/core/executor/full_exit_nft_executor.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	common2 "github.com/bnb-chain/zkbnb/common"
-	"github.com/bnb-chain/zkbnb/core/statedb"
 	"github.com/bnb-chain/zkbnb/dao/nft"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
@@ -47,7 +46,7 @@ func (e *FullExitNftExecutor) Prepare() error {
 	account, err := bc.DB().AccountModel.GetAccountByNameHash(accountNameHash)
 	if err != nil {
 		exist := false
-		for index := range bc.StateDB().PendingNewAccountIndexMap {
+		for index := range bc.StateDB().PendingNewAccountMap {
 			tempAccount, err := bc.StateDB().GetAccount(index)
 			if err != nil {
 				continue
@@ -175,7 +174,6 @@ func (e *FullExitNftExecutor) ApplyTransaction() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.SetPendingUpdateNft(txInfo.NftIndex, emptyNft)
-	stateCache.PendingUpdateNftIndexMap[txInfo.NftIndex] = statedb.StateCachePending
 	return e.BaseExecutor.ApplyTransaction()
 }
 

--- a/core/executor/mint_nft_executor.go
+++ b/core/executor/mint_nft_executor.go
@@ -12,7 +12,6 @@ import (
 	"github.com/bnb-chain/zkbnb-crypto/ffmath"
 	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	common2 "github.com/bnb-chain/zkbnb/common"
-	"github.com/bnb-chain/zkbnb/core/statedb"
 	"github.com/bnb-chain/zkbnb/dao/nft"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
@@ -113,9 +112,6 @@ func (e *MintNftExecutor) ApplyTransaction() error {
 		CreatorTreasuryRate: txInfo.CreatorTreasuryRate,
 		CollectionId:        txInfo.NftCollectionId,
 	})
-	stateCache.PendingUpdateAccountIndexMap[txInfo.CreatorAccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
-	stateCache.PendingNewNftIndexMap[txInfo.NftIndex] = statedb.StateCachePending
 	return e.BaseExecutor.ApplyTransaction()
 }
 

--- a/core/executor/mint_nft_executor.go
+++ b/core/executor/mint_nft_executor.go
@@ -60,7 +60,10 @@ func (e *MintNftExecutor) VerifyInputs() error {
 		return err
 	}
 
-	creatorAccount := e.bc.StateDB().AccountMap[txInfo.CreatorAccountIndex]
+	creatorAccount, err := e.bc.StateDB().GetFormatAccount(txInfo.CreatorAccountIndex)
+	if err != nil {
+		return err
+	}
 	if creatorAccount.CollectionNonce <= txInfo.NftCollectionId {
 		return errors.New("nft collection id is not less than account collection nonce")
 	}
@@ -68,7 +71,10 @@ func (e *MintNftExecutor) VerifyInputs() error {
 		return errors.New("balance is not enough")
 	}
 
-	toAccount := e.bc.StateDB().AccountMap[txInfo.ToAccountIndex]
+	toAccount, err := e.bc.StateDB().GetFormatAccount(txInfo.ToAccountIndex)
+	if err != nil {
+		return err
+	}
 	if txInfo.ToAccountNameHash != toAccount.AccountNameHash {
 		return errors.New("invalid ToAccountNameHash")
 	}
@@ -81,14 +87,23 @@ func (e *MintNftExecutor) ApplyTransaction() error {
 	txInfo := e.txInfo
 
 	// apply changes
-	creatorAccount := bc.StateDB().AccountMap[txInfo.CreatorAccountIndex]
-	gasAccount := bc.StateDB().AccountMap[txInfo.GasAccountIndex]
+	creatorAccount, err := bc.StateDB().GetFormatAccount(txInfo.CreatorAccountIndex)
+	if err != nil {
+		return err
+	}
+	gasAccount, err := bc.StateDB().GetFormatAccount(txInfo.GasAccountIndex)
+	if err != nil {
+		return err
+	}
 
 	creatorAccount.AssetInfo[txInfo.GasFeeAssetId].Balance = ffmath.Sub(creatorAccount.AssetInfo[txInfo.GasFeeAssetId].Balance, txInfo.GasFeeAssetAmount)
 	gasAccount.AssetInfo[txInfo.GasFeeAssetId].Balance = ffmath.Add(gasAccount.AssetInfo[txInfo.GasFeeAssetId].Balance, txInfo.GasFeeAssetAmount)
 	creatorAccount.Nonce++
 
-	bc.StateDB().NftMap[txInfo.NftIndex] = &nft.L2Nft{
+	stateCache := e.bc.StateDB()
+	stateCache.SetPendingUpdateAccount(txInfo.CreatorAccountIndex, creatorAccount)
+	stateCache.SetPendingNewAccount(txInfo.GasAccountIndex, gasAccount)
+	stateCache.SetPendingNewNft(txInfo.NftIndex, &nft.L2Nft{
 		NftIndex:            txInfo.NftIndex,
 		CreatorAccountIndex: txInfo.CreatorAccountIndex,
 		OwnerAccountIndex:   txInfo.ToAccountIndex,
@@ -97,9 +112,7 @@ func (e *MintNftExecutor) ApplyTransaction() error {
 		NftL1TokenId:        types.EmptyL1TokenId,
 		CreatorTreasuryRate: txInfo.CreatorTreasuryRate,
 		CollectionId:        txInfo.NftCollectionId,
-	}
-
-	stateCache := e.bc.StateDB()
+	})
 	stateCache.PendingUpdateAccountIndexMap[txInfo.CreatorAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
 	stateCache.PendingNewNftIndexMap[txInfo.NftIndex] = statedb.StateCachePending

--- a/core/executor/mint_nft_executor.go
+++ b/core/executor/mint_nft_executor.go
@@ -101,7 +101,7 @@ func (e *MintNftExecutor) ApplyTransaction() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.SetPendingUpdateAccount(txInfo.CreatorAccountIndex, creatorAccount)
-	stateCache.SetPendingNewAccount(txInfo.GasAccountIndex, gasAccount)
+	stateCache.SetPendingUpdateAccount(txInfo.GasAccountIndex, gasAccount)
 	stateCache.SetPendingNewNft(txInfo.NftIndex, &nft.L2Nft{
 		NftIndex:            txInfo.NftIndex,
 		CreatorAccountIndex: txInfo.CreatorAccountIndex,

--- a/core/executor/register_zns_executor.go
+++ b/core/executor/register_zns_executor.go
@@ -12,7 +12,6 @@ import (
 	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	common2 "github.com/bnb-chain/zkbnb/common"
 	"github.com/bnb-chain/zkbnb/common/chain"
-	"github.com/bnb-chain/zkbnb/core/statedb"
 	"github.com/bnb-chain/zkbnb/dao/account"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/tree"
@@ -58,7 +57,7 @@ func (e *RegisterZnsExecutor) VerifyInputs() error {
 		return errors.New("invalid account name, already registered")
 	}
 
-	for index := range bc.StateDB().PendingNewAccountIndexMap {
+	for index := range bc.StateDB().PendingNewAccountMap {
 		account, err := bc.StateDB().GetFormatAccount(index)
 		if err != nil {
 			continue
@@ -106,7 +105,6 @@ func (e *RegisterZnsExecutor) ApplyTransaction() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.SetPendingNewAccount(txInfo.AccountIndex, formatAccount)
-	stateCache.PendingNewAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
 	return e.BaseExecutor.ApplyTransaction()
 }
 

--- a/core/executor/register_zns_executor.go
+++ b/core/executor/register_zns_executor.go
@@ -59,7 +59,11 @@ func (e *RegisterZnsExecutor) VerifyInputs() error {
 	}
 
 	for index := range bc.StateDB().PendingNewAccountIndexMap {
-		if txInfo.AccountName == bc.StateDB().AccountMap[index].AccountName {
+		account, err := bc.StateDB().GetFormatAccount(index)
+		if err != nil {
+			continue
+		}
+		if txInfo.AccountName == account.AccountName {
 			return errors.New("invalid account name, already registered")
 		}
 	}
@@ -88,7 +92,7 @@ func (e *RegisterZnsExecutor) ApplyTransaction() error {
 		AssetRoot:       common.Bytes2Hex(tree.NilAccountAssetRoot),
 		Status:          account.AccountStatusConfirmed,
 	}
-	bc.StateDB().AccountMap[txInfo.AccountIndex], err = chain.ToFormatAccountInfo(newAccount)
+	formatAccount, err := chain.ToFormatAccountInfo(newAccount)
 	if err != nil {
 		return err
 	}
@@ -101,6 +105,7 @@ func (e *RegisterZnsExecutor) ApplyTransaction() error {
 	bc.StateDB().AccountAssetTrees = append(bc.StateDB().AccountAssetTrees, emptyAssetTree)
 
 	stateCache := e.bc.StateDB()
+	stateCache.SetPendingNewAccount(txInfo.AccountIndex, formatAccount)
 	stateCache.PendingNewAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
 	return e.BaseExecutor.ApplyTransaction()
 }

--- a/core/executor/remove_liquidity_executor.go
+++ b/core/executor/remove_liquidity_executor.go
@@ -12,7 +12,6 @@ import (
 	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	common2 "github.com/bnb-chain/zkbnb/common"
 	"github.com/bnb-chain/zkbnb/common/chain"
-	"github.com/bnb-chain/zkbnb/core/statedb"
 	"github.com/bnb-chain/zkbnb/dao/liquidity"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
@@ -215,10 +214,6 @@ func (e *RemoveLiquidityExecutor) ApplyTransaction() error {
 		TreasuryAccountIndex: e.newPoolInfo.TreasuryAccountIndex,
 		TreasuryRate:         e.newPoolInfo.TreasuryRate,
 	})
-	stateCache.PendingUpdateAccountIndexMap[txInfo.FromAccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateAccountIndexMap[treasuryAccount.AccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateLiquidityIndexMap[txInfo.PairIndex] = statedb.StateCachePending
 	return e.BaseExecutor.ApplyTransaction()
 }
 

--- a/core/executor/remove_liquidity_executor.go
+++ b/core/executor/remove_liquidity_executor.go
@@ -59,6 +59,20 @@ func (e *RemoveLiquidityExecutor) Prepare() error {
 		return err
 	}
 
+	err = e.bc.StateDB().PrepareAccountsAndAssets(map[int64]map[int64]bool{
+		txInfo.FromAccountIndex: {
+			txInfo.PairIndex: true,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	err = e.fillTxInfo()
+	if err != nil {
+		return err
+	}
+
 	// Mark the tree states that would be affected in this executor.
 	e.MarkLiquidityDirty(txInfo.PairIndex)
 	e.MarkAccountAssetsDirty(txInfo.FromAccountIndex, []int64{txInfo.GasFeeAssetId, txInfo.AssetAId, txInfo.AssetBId, txInfo.PairIndex})

--- a/core/executor/remove_liquidity_executor.go
+++ b/core/executor/remove_liquidity_executor.go
@@ -59,20 +59,6 @@ func (e *RemoveLiquidityExecutor) Prepare() error {
 		return err
 	}
 
-	err = e.bc.StateDB().PrepareAccountsAndAssets(map[int64]map[int64]bool{
-		txInfo.FromAccountIndex: {
-			txInfo.PairIndex: true,
-		},
-	})
-	if err != nil {
-		return err
-	}
-
-	err = e.fillTxInfo()
-	if err != nil {
-		return err
-	}
-
 	// Mark the tree states that would be affected in this executor.
 	e.MarkLiquidityDirty(txInfo.PairIndex)
 	e.MarkAccountAssetsDirty(txInfo.FromAccountIndex, []int64{txInfo.GasFeeAssetId, txInfo.AssetAId, txInfo.AssetBId, txInfo.PairIndex})

--- a/core/executor/swap_executor.go
+++ b/core/executor/swap_executor.go
@@ -74,7 +74,10 @@ func (e *SwapExecutor) VerifyInputs() error {
 		return err
 	}
 
-	fromAccount := bc.StateDB().AccountMap[txInfo.FromAccountIndex]
+	fromAccount, err := bc.StateDB().GetFormatAccount(txInfo.FromAccountIndex)
+	if err != nil {
+		return err
+	}
 	if txInfo.GasFeeAssetId != txInfo.AssetAId {
 		if fromAccount.AssetInfo[txInfo.GasFeeAssetId].Balance.Cmp(txInfo.GasFeeAssetAmount) < 0 {
 			return errors.New("invalid gas asset amount")
@@ -89,7 +92,10 @@ func (e *SwapExecutor) VerifyInputs() error {
 		}
 	}
 
-	liquidityModel := bc.StateDB().LiquidityMap[txInfo.PairIndex]
+	liquidityModel, err := bc.StateDB().GetLiquidity(txInfo.PairIndex)
+	if err != nil {
+		return err
+	}
 	liquidityInfo, err := constructLiquidityInfo(liquidityModel)
 	if err != nil {
 		logx.Errorf("construct liquidity info error, err: %v", err)
@@ -127,8 +133,14 @@ func (e *SwapExecutor) ApplyTransaction() error {
 	txInfo := e.txInfo
 
 	// apply changes
-	fromAccount := bc.StateDB().AccountMap[txInfo.FromAccountIndex]
-	gasAccount := bc.StateDB().AccountMap[txInfo.GasAccountIndex]
+	fromAccount, err := bc.StateDB().GetFormatAccount(txInfo.FromAccountIndex)
+	if err != nil {
+		return err
+	}
+	gasAccount, err := bc.StateDB().GetFormatAccount(txInfo.GasAccountIndex)
+	if err != nil {
+		return err
+	}
 
 	fromAccount.AssetInfo[txInfo.AssetAId].Balance = ffmath.Sub(fromAccount.AssetInfo[txInfo.AssetAId].Balance, txInfo.AssetAAmount)
 	fromAccount.AssetInfo[txInfo.AssetBId].Balance = ffmath.Add(fromAccount.AssetInfo[txInfo.AssetBId].Balance, txInfo.AssetBAmountDelta)
@@ -136,8 +148,15 @@ func (e *SwapExecutor) ApplyTransaction() error {
 	gasAccount.AssetInfo[txInfo.GasFeeAssetId].Balance = ffmath.Add(gasAccount.AssetInfo[txInfo.GasFeeAssetId].Balance, txInfo.GasFeeAssetAmount)
 	fromAccount.Nonce++
 
-	liquidityModel := bc.StateDB().LiquidityMap[txInfo.PairIndex]
-	bc.StateDB().LiquidityMap[txInfo.PairIndex] = &liquidity.Liquidity{
+	liquidityModel, err := bc.StateDB().GetLiquidity(txInfo.PairIndex)
+	if err != nil {
+		return err
+	}
+
+	stateCache := e.bc.StateDB()
+	stateCache.SetPendingUpdateAccount(txInfo.FromAccountIndex, fromAccount)
+	stateCache.SetPendingUpdateAccount(txInfo.GasAccountIndex, gasAccount)
+	stateCache.SetPendingUpdateLiquidity(txInfo.PairIndex, &liquidity.Liquidity{
 		Model:                liquidityModel.Model,
 		PairIndex:            e.newPoolInfo.PairIndex,
 		AssetAId:             liquidityModel.AssetAId,
@@ -149,9 +168,7 @@ func (e *SwapExecutor) ApplyTransaction() error {
 		FeeRate:              e.newPoolInfo.FeeRate,
 		TreasuryAccountIndex: e.newPoolInfo.TreasuryAccountIndex,
 		TreasuryRate:         e.newPoolInfo.TreasuryRate,
-	}
-
-	stateCache := e.bc.StateDB()
+	})
 	stateCache.PendingUpdateAccountIndexMap[txInfo.FromAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
 	stateCache.PendingUpdateLiquidityIndexMap[txInfo.PairIndex] = statedb.StateCachePending
@@ -162,7 +179,10 @@ func (e *SwapExecutor) fillTxInfo() error {
 	bc := e.bc
 	txInfo := e.txInfo
 
-	liquidityModel := bc.StateDB().LiquidityMap[txInfo.PairIndex]
+	liquidityModel, err := bc.StateDB().GetLiquidity(txInfo.PairIndex)
+	if err != nil {
+		return err
+	}
 
 	liquidityInfo, err := constructLiquidityInfo(liquidityModel)
 	if err != nil {
@@ -279,7 +299,10 @@ func (e *SwapExecutor) GenerateTxDetails() ([]*tx.TxDetail, error) {
 
 	fromAccount := copiedAccounts[txInfo.FromAccountIndex]
 	gasAccount := copiedAccounts[txInfo.GasAccountIndex]
-	liquidityModel := e.bc.StateDB().LiquidityMap[txInfo.PairIndex]
+	liquidityModel, err := e.bc.StateDB().GetLiquidity(txInfo.PairIndex)
+	if err != nil {
+		return nil, err
+	}
 	liquidityInfo, err := constructLiquidityInfo(liquidityModel)
 	if err != nil {
 		logx.Errorf("construct liquidity info error, err: %v", err)

--- a/core/executor/swap_executor.go
+++ b/core/executor/swap_executor.go
@@ -12,7 +12,6 @@ import (
 	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	common2 "github.com/bnb-chain/zkbnb/common"
 	"github.com/bnb-chain/zkbnb/common/chain"
-	"github.com/bnb-chain/zkbnb/core/statedb"
 	"github.com/bnb-chain/zkbnb/dao/liquidity"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
@@ -169,9 +168,6 @@ func (e *SwapExecutor) ApplyTransaction() error {
 		TreasuryAccountIndex: e.newPoolInfo.TreasuryAccountIndex,
 		TreasuryRate:         e.newPoolInfo.TreasuryRate,
 	})
-	stateCache.PendingUpdateAccountIndexMap[txInfo.FromAccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateLiquidityIndexMap[txInfo.PairIndex] = statedb.StateCachePending
 	return e.BaseExecutor.ApplyTransaction()
 }
 

--- a/core/executor/transfer_executor.go
+++ b/core/executor/transfer_executor.go
@@ -10,7 +10,6 @@ import (
 	"github.com/bnb-chain/zkbnb-crypto/ffmath"
 	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	common2 "github.com/bnb-chain/zkbnb/common"
-	"github.com/bnb-chain/zkbnb/core/statedb"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
 )
@@ -108,9 +107,6 @@ func (e *TransferExecutor) ApplyTransaction() error {
 	stateCache.SetPendingUpdateAccount(txInfo.FromAccountIndex, fromAccount)
 	stateCache.SetPendingUpdateAccount(txInfo.ToAccountIndex, toAccount)
 	stateCache.SetPendingUpdateAccount(txInfo.GasAccountIndex, gasAccount)
-	stateCache.PendingUpdateAccountIndexMap[txInfo.FromAccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateAccountIndexMap[txInfo.ToAccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
 	return e.BaseExecutor.ApplyTransaction()
 }
 

--- a/core/executor/transfer_nft_executor.go
+++ b/core/executor/transfer_nft_executor.go
@@ -11,7 +11,6 @@ import (
 	"github.com/bnb-chain/zkbnb-crypto/ffmath"
 	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	common2 "github.com/bnb-chain/zkbnb/common"
-	"github.com/bnb-chain/zkbnb/core/statedb"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
 )
@@ -113,9 +112,6 @@ func (e *TransferNftExecutor) ApplyTransaction() error {
 	stateCache.SetPendingUpdateAccount(txInfo.FromAccountIndex, fromAccount)
 	stateCache.SetPendingUpdateAccount(txInfo.GasAccountIndex, gasAccount)
 	stateCache.SetPendingUpdateNft(txInfo.NftIndex, nft)
-	stateCache.PendingUpdateAccountIndexMap[txInfo.FromAccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateNftIndexMap[txInfo.NftIndex] = statedb.StateCachePending
 	return e.BaseExecutor.ApplyTransaction()
 }
 

--- a/core/executor/update_pair_rate_executor.go
+++ b/core/executor/update_pair_rate_executor.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	"github.com/bnb-chain/zkbnb/common"
-	"github.com/bnb-chain/zkbnb/core/statedb"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
 )
@@ -79,7 +78,6 @@ func (e *UpdatePairRateExecutor) ApplyTransaction() error {
 
 	stateCache := e.bc.StateDB()
 	stateCache.SetPendingUpdateLiquidity(txInfo.PairIndex, liquidity)
-	stateCache.PendingUpdateLiquidityIndexMap[txInfo.PairIndex] = statedb.StateCachePending
 	return e.BaseExecutor.ApplyTransaction()
 }
 

--- a/core/executor/withdraw_executor.go
+++ b/core/executor/withdraw_executor.go
@@ -52,7 +52,10 @@ func (e *WithdrawExecutor) VerifyInputs() error {
 		return err
 	}
 
-	fromAccount := e.bc.StateDB().AccountMap[txInfo.FromAccountIndex]
+	fromAccount, err := e.bc.StateDB().GetFormatAccount(txInfo.FromAccountIndex)
+	if err != nil {
+		return err
+	}
 	if txInfo.GasFeeAssetId != txInfo.AssetId {
 		if fromAccount.AssetInfo[txInfo.AssetId].Balance.Cmp(txInfo.AssetAmount) < 0 {
 			return errors.New("invalid asset amount")
@@ -74,8 +77,14 @@ func (e *WithdrawExecutor) ApplyTransaction() error {
 	bc := e.bc
 	txInfo := e.txInfo
 
-	fromAccount := bc.StateDB().AccountMap[txInfo.FromAccountIndex]
-	gasAccount := bc.StateDB().AccountMap[txInfo.GasAccountIndex]
+	fromAccount, err := bc.StateDB().GetFormatAccount(txInfo.FromAccountIndex)
+	if err != nil {
+		return err
+	}
+	gasAccount, err := bc.StateDB().GetFormatAccount(txInfo.GasAccountIndex)
+	if err != nil {
+		return err
+	}
 
 	// apply changes
 	fromAccount.AssetInfo[txInfo.AssetId].Balance = ffmath.Sub(fromAccount.AssetInfo[txInfo.AssetId].Balance, txInfo.AssetAmount)

--- a/core/executor/withdraw_executor.go
+++ b/core/executor/withdraw_executor.go
@@ -11,7 +11,6 @@ import (
 	"github.com/bnb-chain/zkbnb-crypto/ffmath"
 	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	common2 "github.com/bnb-chain/zkbnb/common"
-	"github.com/bnb-chain/zkbnb/core/statedb"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
 )
@@ -93,8 +92,8 @@ func (e *WithdrawExecutor) ApplyTransaction() error {
 	fromAccount.Nonce++
 
 	stateCache := e.bc.StateDB()
-	stateCache.PendingUpdateAccountIndexMap[txInfo.FromAccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
+	stateCache.SetPendingUpdateAccount(txInfo.FromAccountIndex, fromAccount)
+	stateCache.SetPendingUpdateAccount(txInfo.GasAccountIndex, gasAccount)
 	return e.BaseExecutor.ApplyTransaction()
 }
 

--- a/core/executor/withdraw_nft_executor.go
+++ b/core/executor/withdraw_nft_executor.go
@@ -12,7 +12,6 @@ import (
 	"github.com/bnb-chain/zkbnb-crypto/ffmath"
 	"github.com/bnb-chain/zkbnb-crypto/wasm/legend/legendTxTypes"
 	common2 "github.com/bnb-chain/zkbnb/common"
-	"github.com/bnb-chain/zkbnb/core/statedb"
 	"github.com/bnb-chain/zkbnb/dao/nft"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
@@ -141,9 +140,6 @@ func (e *WithdrawNftExecutor) ApplyTransaction() error {
 		CreatorTreasuryRate: newNftInfo.CreatorTreasuryRate,
 		CollectionId:        newNftInfo.CollectionId,
 	})
-	stateCache.PendingUpdateAccountIndexMap[txInfo.AccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateAccountIndexMap[txInfo.GasAccountIndex] = statedb.StateCachePending
-	stateCache.PendingUpdateNftIndexMap[txInfo.NftIndex] = statedb.StateCachePending
 	return e.BaseExecutor.ApplyTransaction()
 }
 

--- a/core/statedb/state_cache.go
+++ b/core/statedb/state_cache.go
@@ -4,6 +4,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/bnb-chain/zkbnb-crypto/legend/circuit/bn254/std"
+	"github.com/bnb-chain/zkbnb/dao/liquidity"
+	"github.com/bnb-chain/zkbnb/dao/nft"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/types"
 )
@@ -32,6 +34,14 @@ type StateCache struct {
 	PendingUpdateLiquidityIndexMap map[int64]int
 	PendingUpdateNftIndexMap       map[int64]int
 
+	// Record the flat data that should be updated.
+	PendingNewAccountMap      map[int64]*types.AccountInfo
+	PendingNewLiquidityMap    map[int64]*liquidity.Liquidity
+	PendingNewNftMap          map[int64]*nft.L2Nft
+	PendingUpdateAccountMap   map[int64]*types.AccountInfo
+	PendingUpdateLiquidityMap map[int64]*liquidity.Liquidity
+	PendingUpdateNftMap       map[int64]*nft.L2Nft
+
 	// Record the tree states that should be updated.
 	dirtyAccountsAndAssetsMap map[int64]map[int64]bool
 	dirtyLiquidityMap         map[int64]bool
@@ -49,6 +59,13 @@ func NewStateCache(stateRoot string) *StateCache {
 		PendingUpdateAccountIndexMap:   make(map[int64]int, 0),
 		PendingUpdateLiquidityIndexMap: make(map[int64]int, 0),
 		PendingUpdateNftIndexMap:       make(map[int64]int, 0),
+
+		PendingNewAccountMap:      make(map[int64]*types.AccountInfo, 0),
+		PendingNewLiquidityMap:    make(map[int64]*liquidity.Liquidity, 0),
+		PendingNewNftMap:          make(map[int64]*nft.L2Nft, 0),
+		PendingUpdateAccountMap:   make(map[int64]*types.AccountInfo, 0),
+		PendingUpdateLiquidityMap: make(map[int64]*liquidity.Liquidity, 0),
+		PendingUpdateNftMap:       make(map[int64]*nft.L2Nft, 0),
 
 		PubData:                         make([]byte, 0),
 		PriorityOperations:              0,
@@ -91,4 +108,64 @@ func (c *StateCache) MarkLiquidityDirty(pairIndex int64) {
 
 func (c *StateCache) MarkNftDirty(nftIndex int64) {
 	c.dirtyNftMap[nftIndex] = true
+}
+
+func (c *StateCache) GetPendingAccount(accountIndex int64) (*types.AccountInfo, bool) {
+	account, exist := c.PendingNewAccountMap[accountIndex]
+	if exist {
+		return account, exist
+	}
+	account, exist = c.PendingUpdateAccountMap[accountIndex]
+	if exist {
+		return account, exist
+	}
+	return nil, false
+}
+
+func (c *StateCache) GetPendingLiquidity(pairIndex int64) (*liquidity.Liquidity, bool) {
+	liquidity, exist := c.PendingNewLiquidityMap[pairIndex]
+	if exist {
+		return liquidity, exist
+	}
+	liquidity, exist = c.PendingUpdateLiquidityMap[pairIndex]
+	if exist {
+		return liquidity, exist
+	}
+	return nil, false
+}
+
+func (c *StateCache) GetPendingNft(nftIndex int64) (*nft.L2Nft, bool) {
+	nft, exist := c.PendingNewNftMap[nftIndex]
+	if exist {
+		return nft, exist
+	}
+	nft, exist = c.PendingUpdateNftMap[nftIndex]
+	if exist {
+		return nft, exist
+	}
+	return nil, false
+}
+
+func (c *StateCache) SetPendingNewAccount(accountIndex int64, account *types.AccountInfo) {
+	c.PendingNewAccountMap[accountIndex] = account
+}
+
+func (c *StateCache) SetPendingUpdateAccount(accountIndex int64, account *types.AccountInfo) {
+	c.PendingUpdateAccountMap[accountIndex] = account
+}
+
+func (c *StateCache) SetPendingUpdateLiquidity(pairIndex int64, liquidity *liquidity.Liquidity) {
+	c.PendingUpdateLiquidityMap[pairIndex] = liquidity
+}
+
+func (c *StateCache) SetPendingNewLiquidity(pairIndex int64, liquidity *liquidity.Liquidity) {
+	c.PendingNewLiquidityMap[pairIndex] = liquidity
+}
+
+func (c *StateCache) SetPendingNewNft(nftIndex int64, nft *nft.L2Nft) {
+	c.PendingNewNftMap[nftIndex] = nft
+}
+
+func (c *StateCache) SetPendingUpdateNft(nftIndex int64, nft *nft.L2Nft) {
+	c.PendingUpdateNftMap[nftIndex] = nft
 }

--- a/core/statedb/state_cache.go
+++ b/core/statedb/state_cache.go
@@ -10,12 +10,6 @@ import (
 	"github.com/bnb-chain/zkbnb/types"
 )
 
-const (
-	_ = iota
-	StateCachePending
-	StateCacheCached
-)
-
 type StateCache struct {
 	StateRoot string
 	// Updated in executor's GeneratePubData method.
@@ -25,14 +19,6 @@ type StateCache struct {
 	PendingOnChainOperationsPubData [][]byte
 	PendingOnChainOperationsHash    []byte
 	Txs                             []*tx.Tx
-
-	// Record the flat states that should be updated.
-	PendingNewAccountIndexMap      map[int64]int
-	PendingNewLiquidityIndexMap    map[int64]int
-	PendingNewNftIndexMap          map[int64]int
-	PendingUpdateAccountIndexMap   map[int64]int
-	PendingUpdateLiquidityIndexMap map[int64]int
-	PendingUpdateNftIndexMap       map[int64]int
 
 	// Record the flat data that should be updated.
 	PendingNewAccountMap      map[int64]*types.AccountInfo
@@ -52,13 +38,6 @@ func NewStateCache(stateRoot string) *StateCache {
 	return &StateCache{
 		StateRoot: stateRoot,
 		Txs:       make([]*tx.Tx, 0),
-
-		PendingNewAccountIndexMap:      make(map[int64]int, 0),
-		PendingNewLiquidityIndexMap:    make(map[int64]int, 0),
-		PendingNewNftIndexMap:          make(map[int64]int, 0),
-		PendingUpdateAccountIndexMap:   make(map[int64]int, 0),
-		PendingUpdateLiquidityIndexMap: make(map[int64]int, 0),
-		PendingUpdateNftIndexMap:       make(map[int64]int, 0),
 
 		PendingNewAccountMap:      make(map[int64]*types.AccountInfo, 0),
 		PendingNewLiquidityMap:    make(map[int64]*liquidity.Liquidity, 0),

--- a/core/statedb/statedb.go
+++ b/core/statedb/statedb.go
@@ -36,15 +36,15 @@ type CacheConfig struct {
 }
 
 func (c *CacheConfig) sanitize() *CacheConfig {
-	if c.AccountCacheSize == 0 {
+	if c.AccountCacheSize <= 0 {
 		c.AccountCacheSize = DefaultCacheConfig.AccountCacheSize
 	}
 
-	if c.LiquidityCacheSize == 0 {
+	if c.LiquidityCacheSize <= 0 {
 		c.LiquidityCacheSize = DefaultCacheConfig.LiquidityCacheSize
 	}
 
-	if c.NftCacheSize == 0 {
+	if c.NftCacheSize <= 0 {
 		c.NftCacheSize = DefaultCacheConfig.NftCacheSize
 	}
 

--- a/core/statedb/statedb.go
+++ b/core/statedb/statedb.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/mimc"
 	"github.com/ethereum/go-ethereum/common"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/zeromicro/go-zero/core/logx"
 
 	bsmt "github.com/bnb-chain/zkbnb-smt"
@@ -20,6 +21,36 @@ import (
 	"github.com/bnb-chain/zkbnb/types"
 )
 
+var (
+	DefaultCacheConfig = CacheConfig{
+		AccountCacheSize:   2048,
+		LiquidityCacheSize: 2048,
+		NftCacheSize:       2048,
+	}
+)
+
+type CacheConfig struct {
+	AccountCacheSize   int
+	LiquidityCacheSize int
+	NftCacheSize       int
+}
+
+func (c *CacheConfig) sanitize() *CacheConfig {
+	if c.AccountCacheSize == 0 {
+		c.AccountCacheSize = DefaultCacheConfig.AccountCacheSize
+	}
+
+	if c.LiquidityCacheSize == 0 {
+		c.LiquidityCacheSize = DefaultCacheConfig.LiquidityCacheSize
+	}
+
+	if c.NftCacheSize == 0 {
+		c.NftCacheSize = DefaultCacheConfig.NftCacheSize
+	}
+
+	return c
+}
+
 type StateDB struct {
 	dryRun bool
 	// State cache
@@ -28,9 +59,9 @@ type StateDB struct {
 	redisCache dbcache.Cache
 
 	// Flat state
-	AccountMap   map[int64]*types.AccountInfo
-	LiquidityMap map[int64]*liquidity.Liquidity
-	NftMap       map[int64]*nft.L2Nft
+	AccountCache   *lru.Cache //map[int64]*types.AccountInfo
+	LiquidityCache *lru.Cache //map[int64]*liquidity.Liquidity
+	NftCache       *lru.Cache //map[int64]*nft.L2Nft
 
 	// Tree state
 	AccountTree       bsmt.SparseMerkleTree
@@ -40,7 +71,9 @@ type StateDB struct {
 	TreeCtx           *tree.Context
 }
 
-func NewStateDB(treeCtx *tree.Context, chainDb *ChainDB, redisCache dbcache.Cache, stateRoot string, curHeight int64) (*StateDB, error) {
+func NewStateDB(treeCtx *tree.Context, chainDb *ChainDB,
+	redisCache dbcache.Cache, cacheConfig *CacheConfig,
+	stateRoot string, curHeight int64) (*StateDB, error) {
 	err := tree.SetupTreeDB(treeCtx)
 	if err != nil {
 		logx.Error("setup tree db failed: ", err)
@@ -74,13 +107,31 @@ func NewStateDB(treeCtx *tree.Context, chainDb *ChainDB, redisCache dbcache.Cach
 		logx.Error("dbinitializer nft tree failed:", err)
 		return nil, err
 	}
+
+	cacheConfig.sanitize()
+	accountCache, err := lru.New(cacheConfig.AccountCacheSize)
+	if err != nil {
+		logx.Error("init account cache failed:", err)
+		return nil, err
+	}
+	liquidityCache, err := lru.New(cacheConfig.LiquidityCacheSize)
+	if err != nil {
+		logx.Error("init liquidity cache failed:", err)
+		return nil, err
+	}
+	nftCache, err := lru.New(cacheConfig.NftCacheSize)
+	if err != nil {
+		logx.Error("init nft cache failed:", err)
+		return nil, err
+	}
+
 	return &StateDB{
-		StateCache:   NewStateCache(stateRoot),
-		chainDb:      chainDb,
-		redisCache:   redisCache,
-		AccountMap:   make(map[int64]*types.AccountInfo),
-		LiquidityMap: make(map[int64]*liquidity.Liquidity),
-		NftMap:       make(map[int64]*nft.L2Nft),
+		StateCache:     NewStateCache(stateRoot),
+		chainDb:        chainDb,
+		redisCache:     redisCache,
+		AccountCache:   accountCache,
+		LiquidityCache: liquidityCache,
+		NftCache:       nftCache,
 
 		AccountTree:       accountTree,
 		LiquidityTree:     liquidityTree,
@@ -90,33 +141,119 @@ func NewStateDB(treeCtx *tree.Context, chainDb *ChainDB, redisCache dbcache.Cach
 	}, nil
 }
 
-func NewStateDBForDryRun(redisCache dbcache.Cache, chainDb *ChainDB) *StateDB {
-	return &StateDB{
-		dryRun:       true,
-		redisCache:   redisCache,
-		chainDb:      chainDb,
-		AccountMap:   make(map[int64]*types.AccountInfo),
-		LiquidityMap: make(map[int64]*liquidity.Liquidity),
-		NftMap:       make(map[int64]*nft.L2Nft),
-		StateCache:   NewStateCache(""),
-	}
-}
-
-func (s *StateDB) GetAccount(accountIndex int64) interface{} {
-	// to save account to cache, we need to convert it
-	account, err := chain.FromFormatAccountInfo(s.AccountMap[accountIndex])
+func NewStateDBForDryRun(redisCache dbcache.Cache, cacheConfig *CacheConfig, chainDb *ChainDB) (*StateDB, error) {
+	accountCache, err := lru.New(cacheConfig.AccountCacheSize)
 	if err != nil {
-		return nil
+		logx.Error("init account cache failed:", err)
+		return nil, err
 	}
-	return account
+	liquidityCache, err := lru.New(cacheConfig.LiquidityCacheSize)
+	if err != nil {
+		logx.Error("init liquidity cache failed:", err)
+		return nil, err
+	}
+	nftCache, err := lru.New(cacheConfig.NftCacheSize)
+	if err != nil {
+		logx.Error("init nft cache failed:", err)
+		return nil, err
+	}
+	return &StateDB{
+		dryRun:         true,
+		redisCache:     redisCache,
+		chainDb:        chainDb,
+		AccountCache:   accountCache,
+		LiquidityCache: liquidityCache,
+		NftCache:       nftCache,
+		StateCache:     NewStateCache(""),
+	}, nil
 }
 
-func (s *StateDB) GetLiquidity(pairIndex int64) interface{} {
-	return s.LiquidityMap[pairIndex]
+func (s *StateDB) GetFormatAccount(accountIndex int64) (*types.AccountInfo, error) {
+	pending, exist := s.StateCache.GetPendingAccount(accountIndex)
+	if exist {
+		return pending, nil
+	}
+
+	cached, exist := s.AccountCache.Get(accountIndex)
+	if exist {
+		return cached.(*types.AccountInfo), nil
+	}
+
+	account, err := s.chainDb.AccountModel.GetAccountByIndex(accountIndex)
+	if err != nil {
+		return nil, err
+	}
+	formatAccount, err := chain.ToFormatAccountInfo(account)
+	if err != nil {
+		return nil, err
+	}
+	s.AccountCache.Add(accountIndex, formatAccount)
+	return formatAccount, nil
 }
 
-func (s *StateDB) GetNft(nftIndex int64) interface{} {
-	return s.NftMap[nftIndex]
+func (s *StateDB) GetAccount(accountIndex int64) (*account.Account, error) {
+	pending, exist := s.StateCache.GetPendingAccount(accountIndex)
+	if exist {
+		account, err := chain.FromFormatAccountInfo(pending)
+		if err != nil {
+			return nil, err
+		}
+		return account, nil
+	}
+
+	cached, exist := s.AccountCache.Get(accountIndex)
+	if exist {
+		// to save account to cache, we need to convert it
+		account, err := chain.FromFormatAccountInfo(cached.(*types.AccountInfo))
+		if err == nil {
+			return account, nil
+		}
+	}
+
+	account, err := s.chainDb.AccountModel.GetAccountByIndex(accountIndex)
+	if err != nil {
+		return nil, err
+	}
+	formatAccount, err := chain.ToFormatAccountInfo(account)
+	if err != nil {
+		return nil, err
+	}
+	s.AccountCache.Add(accountIndex, formatAccount)
+	return account, nil
+}
+
+func (s *StateDB) GetLiquidity(pairIndex int64) (*liquidity.Liquidity, error) {
+	pending, exist := s.StateCache.GetPendingLiquidity(pairIndex)
+	if exist {
+		return pending, nil
+	}
+	cached, exist := s.LiquidityCache.Get(pairIndex)
+	if exist {
+		return cached.(*liquidity.Liquidity), nil
+	}
+	liquidity, err := s.chainDb.LiquidityModel.GetLiquidityByIndex(pairIndex)
+	if err != nil {
+		return nil, err
+	}
+	s.LiquidityCache.Add(pairIndex, liquidity)
+	return liquidity, nil
+}
+
+func (s *StateDB) GetNft(nftIndex int64) (*nft.L2Nft, error) {
+	pending, exist := s.StateCache.GetPendingNft(nftIndex)
+	if exist {
+		return pending, nil
+	}
+	cached, exist := s.NftCache.Get(nftIndex)
+	if exist {
+		return cached.(*nft.L2Nft), nil
+	}
+	nft, err := s.chainDb.L2NftModel.GetNft(nftIndex)
+	if err != nil {
+		return nil, err
+	}
+	s.NftCache.Add(nftIndex, nft)
+	return nft, nil
 }
 
 func (s *StateDB) syncPendingStateToRedis(pendingMap map[int64]int, getKey func(int64) string, getValue func(int64) interface{}) error {
@@ -136,31 +273,42 @@ func (s *StateDB) syncPendingStateToRedis(pendingMap map[int64]int, getKey func(
 }
 
 func (s *StateDB) SyncStateCacheToRedis() error {
-
+	getAccount := func(index int64) interface{} {
+		account, _ := s.GetAccount(index)
+		return account
+	}
+	getLiquidity := func(index int64) interface{} {
+		liquidity, _ := s.GetLiquidity(index)
+		return liquidity
+	}
+	getNft := func(index int64) interface{} {
+		nft, _ := s.GetNft(index)
+		return nft
+	}
 	// Sync new create to cache.
-	err := s.syncPendingStateToRedis(s.PendingNewAccountIndexMap, dbcache.AccountKeyByIndex, s.GetAccount)
+	err := s.syncPendingStateToRedis(s.PendingNewAccountIndexMap, dbcache.AccountKeyByIndex, getAccount)
 	if err != nil {
 		return err
 	}
-	err = s.syncPendingStateToRedis(s.PendingNewLiquidityIndexMap, dbcache.LiquidityKeyByIndex, s.GetLiquidity)
+	err = s.syncPendingStateToRedis(s.PendingNewLiquidityIndexMap, dbcache.LiquidityKeyByIndex, getLiquidity)
 	if err != nil {
 		return err
 	}
-	err = s.syncPendingStateToRedis(s.PendingNewNftIndexMap, dbcache.NftKeyByIndex, s.GetNft)
+	err = s.syncPendingStateToRedis(s.PendingNewNftIndexMap, dbcache.NftKeyByIndex, getNft)
 	if err != nil {
 		return err
 	}
 
 	// Sync pending update to cache.
-	err = s.syncPendingStateToRedis(s.PendingUpdateAccountIndexMap, dbcache.AccountKeyByIndex, s.GetAccount)
+	err = s.syncPendingStateToRedis(s.PendingUpdateAccountIndexMap, dbcache.AccountKeyByIndex, getAccount)
 	if err != nil {
 		return err
 	}
-	err = s.syncPendingStateToRedis(s.PendingUpdateLiquidityIndexMap, dbcache.LiquidityKeyByIndex, s.GetLiquidity)
+	err = s.syncPendingStateToRedis(s.PendingUpdateLiquidityIndexMap, dbcache.LiquidityKeyByIndex, getLiquidity)
 	if err != nil {
 		return err
 	}
-	err = s.syncPendingStateToRedis(s.PendingUpdateNftIndexMap, dbcache.NftKeyByIndex, s.GetNft)
+	err = s.syncPendingStateToRedis(s.PendingUpdateNftIndexMap, dbcache.NftKeyByIndex, getNft)
 	if err != nil {
 		return err
 	}
@@ -183,7 +331,7 @@ func (s *StateDB) GetPendingAccount(blockHeight int64) ([]*account.Account, []*a
 			continue
 		}
 
-		newAccount, err := chain.FromFormatAccountInfo(s.AccountMap[index])
+		newAccount, err := s.GetAccount(index)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -209,7 +357,7 @@ func (s *StateDB) GetPendingAccount(blockHeight int64) ([]*account.Account, []*a
 			continue
 		}
 
-		newAccount, err := chain.FromFormatAccountInfo(s.AccountMap[index])
+		newAccount, err := s.GetAccount(index)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -234,11 +382,15 @@ func (s *StateDB) GetPendingLiquidity(blockHeight int64) ([]*liquidity.Liquidity
 
 	for index, status := range s.PendingNewLiquidityIndexMap {
 		if status < StateCachePending {
-			logx.Errorf("unexpected 0 status in Statedb cache")
+			logx.Error("unexpected 0 status in Statedb cache")
 			continue
 		}
 
-		newLiquidity := s.LiquidityMap[index]
+		newLiquidity, err := s.GetLiquidity(index)
+		if err != nil {
+			logx.Errorf("get liquidity [%d] fails", index)
+			continue
+		}
 		pendingNewLiquidity = append(pendingNewLiquidity, newLiquidity)
 		pendingNewLiquidityHistory = append(pendingNewLiquidityHistory, &liquidity.LiquidityHistory{
 			PairIndex:            newLiquidity.PairIndex,
@@ -265,7 +417,11 @@ func (s *StateDB) GetPendingLiquidity(blockHeight int64) ([]*liquidity.Liquidity
 			continue
 		}
 
-		newLiquidity := s.LiquidityMap[index]
+		newLiquidity, err := s.GetLiquidity(index)
+		if err != nil {
+			logx.Errorf("get liquidity [%d] fails", index)
+			continue
+		}
 		pendingUpdateLiquidity = append(pendingUpdateLiquidity, newLiquidity)
 		pendingNewLiquidityHistory = append(pendingNewLiquidityHistory, &liquidity.LiquidityHistory{
 			PairIndex:            newLiquidity.PairIndex,
@@ -295,8 +451,11 @@ func (s *StateDB) GetPendingNft(blockHeight int64) ([]*nft.L2Nft, []*nft.L2Nft, 
 			logx.Errorf("unexpected 0 status in Statedb cache")
 			continue
 		}
-
-		newNft := s.NftMap[index]
+		newNft, err := s.GetNft(index)
+		if err != nil {
+			logx.Errorf("get nft [%d] fails", index)
+			continue
+		}
 		pendingNewNft = append(pendingNewNft, newNft)
 		pendingNewNftHistory = append(pendingNewNftHistory, &nft.L2NftHistory{
 			NftIndex:            newNft.NftIndex,
@@ -321,7 +480,11 @@ func (s *StateDB) GetPendingNft(blockHeight int64) ([]*nft.L2Nft, []*nft.L2Nft, 
 			continue
 		}
 
-		newNft := s.NftMap[index]
+		newNft, err := s.GetNft(index)
+		if err != nil {
+			logx.Errorf("get nft [%d] fails", index)
+			continue
+		}
 		pendingUpdateNft = append(pendingUpdateNft, newNft)
 		pendingNewNftHistory = append(pendingNewNftHistory, &nft.L2NftHistory{
 			NftIndex:            newNft.NftIndex,
@@ -349,8 +512,11 @@ func (s *StateDB) DeepCopyAccounts(accountIds []int64) (map[int64]*types.Account
 		if _, ok := accounts[accountId]; ok {
 			continue
 		}
-
-		accountCopy, err := s.AccountMap[accountId].DeepCopy()
+		account, err := s.GetFormatAccount(accountId)
+		if err != nil {
+			return nil, err
+		}
+		accountCopy, err := account.DeepCopy()
 		if err != nil {
 			return nil, err
 		}
@@ -368,27 +534,21 @@ func (s *StateDB) PrepareAccountsAndAssets(accountAssetsMap map[int64]map[int64]
 			if err == nil && redisAccount != nil {
 				formatAccount, err := chain.ToFormatAccountInfo(account)
 				if err == nil {
-					s.AccountMap[accountIndex] = formatAccount
+					s.AccountCache.Add(accountIndex, formatAccount)
 				}
 			}
 		}
 
-		if s.AccountMap[accountIndex] == nil {
-			accountInfo, err := s.chainDb.AccountModel.GetAccountByIndex(accountIndex)
-			if err != nil {
-				return err
-			}
-			s.AccountMap[accountIndex], err = chain.ToFormatAccountInfo(accountInfo)
-			if err != nil {
-				return fmt.Errorf("convert to format account info failed: %v", err)
-			}
+		account, err := s.GetFormatAccount(accountIndex)
+		if err != nil {
+			return err
 		}
-		if s.AccountMap[accountIndex].AssetInfo == nil {
-			s.AccountMap[accountIndex].AssetInfo = make(map[int64]*types.AccountAsset)
+		if account.AssetInfo == nil {
+			account.AssetInfo = make(map[int64]*types.AccountAsset)
 		}
 		for assetId := range assets {
-			if s.AccountMap[accountIndex].AssetInfo[assetId] == nil {
-				s.AccountMap[accountIndex].AssetInfo[assetId] = &types.AccountAsset{
+			if account.AssetInfo[assetId] == nil {
+				account.AssetInfo[assetId] = &types.AccountAsset{
 					AssetId:                  assetId,
 					Balance:                  types.ZeroBigInt,
 					LpAmount:                 types.ZeroBigInt,
@@ -396,6 +556,7 @@ func (s *StateDB) PrepareAccountsAndAssets(accountAssetsMap map[int64]map[int64]
 				}
 			}
 		}
+		s.AccountCache.Add(accountIndex, account)
 	}
 
 	return nil
@@ -406,37 +567,27 @@ func (s *StateDB) PrepareLiquidity(pairIndex int64) error {
 		l := &liquidity.Liquidity{}
 		redisLiquidity, err := s.redisCache.Get(context.Background(), dbcache.LiquidityKeyByIndex(pairIndex), l)
 		if err == nil && redisLiquidity != nil {
-			s.LiquidityMap[pairIndex] = l
+			s.LiquidityCache.Add(pairIndex, l)
 		}
 	}
 
-	if s.LiquidityMap[pairIndex] == nil {
-		liquidityInfo, err := s.chainDb.LiquidityModel.GetLiquidityByIndex(pairIndex)
-		if err != nil {
-			return err
-		}
-		s.LiquidityMap[pairIndex] = liquidityInfo
+	_, err := s.GetLiquidity(pairIndex)
+	if err != nil {
+		return err
 	}
 	return nil
 }
 
-func (s *StateDB) PrepareNft(nftIndex int64) error {
+func (s *StateDB) PrepareNft(nftIndex int64) (*nft.L2Nft, error) {
 	if s.dryRun {
 		n := &nft.L2Nft{}
 		redisNft, err := s.redisCache.Get(context.Background(), dbcache.NftKeyByIndex(nftIndex), n)
 		if err == nil && redisNft != nil {
-			s.NftMap[nftIndex] = n
+			s.NftCache.Add(nftIndex, n)
 		}
 	}
 
-	if s.NftMap[nftIndex] == nil {
-		nftAsset, err := s.chainDb.L2NftModel.GetNft(nftIndex)
-		if err != nil {
-			return err
-		}
-		s.NftMap[nftIndex] = nftAsset
-	}
-	return nil
+	return s.GetNft(nftIndex)
 }
 
 func (s *StateDB) IntermediateRoot(cleanDirty bool) error {
@@ -490,11 +641,15 @@ func (s *StateDB) IntermediateRoot(cleanDirty bool) error {
 }
 
 func (s *StateDB) updateAccountTree(accountIndex int64, assets []int64) error {
+	account, err := s.GetFormatAccount(accountIndex)
+	if err != nil {
+		return err
+	}
 	for _, assetId := range assets {
 		assetLeaf, err := tree.ComputeAccountAssetLeafHash(
-			s.AccountMap[accountIndex].AssetInfo[assetId].Balance.String(),
-			s.AccountMap[accountIndex].AssetInfo[assetId].LpAmount.String(),
-			s.AccountMap[accountIndex].AssetInfo[assetId].OfferCanceledOrFinalized.String(),
+			account.AssetInfo[assetId].Balance.String(),
+			account.AssetInfo[assetId].LpAmount.String(),
+			account.AssetInfo[assetId].OfferCanceledOrFinalized.String(),
 		)
 		if err != nil {
 			return fmt.Errorf("compute new account asset leaf failed: %v", err)
@@ -505,12 +660,12 @@ func (s *StateDB) updateAccountTree(accountIndex int64, assets []int64) error {
 		}
 	}
 
-	s.AccountMap[accountIndex].AssetRoot = common.Bytes2Hex(s.AccountAssetTrees[accountIndex].Root())
+	account.AssetRoot = common.Bytes2Hex(s.AccountAssetTrees[accountIndex].Root())
 	nAccountLeafHash, err := tree.ComputeAccountLeafHash(
-		s.AccountMap[accountIndex].AccountNameHash,
-		s.AccountMap[accountIndex].PublicKey,
-		s.AccountMap[accountIndex].Nonce,
-		s.AccountMap[accountIndex].CollectionNonce,
+		account.AccountNameHash,
+		account.PublicKey,
+		account.Nonce,
+		account.CollectionNonce,
 		s.AccountAssetTrees[accountIndex].Root(),
 	)
 	if err != nil {
@@ -525,16 +680,20 @@ func (s *StateDB) updateAccountTree(accountIndex int64, assets []int64) error {
 }
 
 func (s *StateDB) updateLiquidityTree(pairIndex int64) error {
+	liquidity, err := s.GetLiquidity(pairIndex)
+	if err != nil {
+		return err
+	}
 	nLiquidityAssetLeaf, err := tree.ComputeLiquidityAssetLeafHash(
-		s.LiquidityMap[pairIndex].AssetAId,
-		s.LiquidityMap[pairIndex].AssetA,
-		s.LiquidityMap[pairIndex].AssetBId,
-		s.LiquidityMap[pairIndex].AssetB,
-		s.LiquidityMap[pairIndex].LpAmount,
-		s.LiquidityMap[pairIndex].KLast,
-		s.LiquidityMap[pairIndex].FeeRate,
-		s.LiquidityMap[pairIndex].TreasuryAccountIndex,
-		s.LiquidityMap[pairIndex].TreasuryRate,
+		liquidity.AssetAId,
+		liquidity.AssetA,
+		liquidity.AssetBId,
+		liquidity.AssetB,
+		liquidity.LpAmount,
+		liquidity.KLast,
+		liquidity.FeeRate,
+		liquidity.TreasuryAccountIndex,
+		liquidity.TreasuryRate,
 	)
 	if err != nil {
 		return fmt.Errorf("unable to compute liquidity leaf: %v", err)
@@ -548,14 +707,18 @@ func (s *StateDB) updateLiquidityTree(pairIndex int64) error {
 }
 
 func (s *StateDB) updateNftTree(nftIndex int64) error {
+	nft, err := s.GetNft(nftIndex)
+	if err != nil {
+		return err
+	}
 	nftAssetLeaf, err := tree.ComputeNftAssetLeafHash(
-		s.NftMap[nftIndex].CreatorAccountIndex,
-		s.NftMap[nftIndex].OwnerAccountIndex,
-		s.NftMap[nftIndex].NftContentHash,
-		s.NftMap[nftIndex].NftL1Address,
-		s.NftMap[nftIndex].NftL1TokenId,
-		s.NftMap[nftIndex].CreatorTreasuryRate,
-		s.NftMap[nftIndex].CollectionId,
+		nft.CreatorAccountIndex,
+		nft.OwnerAccountIndex,
+		nft.NftContentHash,
+		nft.NftL1Address,
+		nft.NftL1TokenId,
+		nft.CreatorTreasuryRate,
+		nft.CollectionId,
 	)
 	if err != nil {
 		return fmt.Errorf("unable to compute nft leaf: %v", err)
@@ -569,11 +732,11 @@ func (s *StateDB) updateNftTree(nftIndex int64) error {
 }
 
 func (s *StateDB) GetCommittedNonce(accountIndex int64) (int64, error) {
-	if acc, exist := s.AccountMap[accountIndex]; exist {
-		return acc.Nonce, nil
-	} else {
-		return 0, fmt.Errorf("account does not exist")
+	account, err := s.GetFormatAccount(accountIndex)
+	if err != nil {
+		return 0, err
 	}
+	return account.Nonce, nil
 }
 
 func (s *StateDB) GetPendingNonce(accountIndex int64) (int64, error) {

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.12.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect

--- a/service/apiserver/internal/logic/transaction/getnextnoncelogic.go
+++ b/service/apiserver/internal/logic/transaction/getnextnoncelogic.go
@@ -26,8 +26,11 @@ func NewGetNextNonceLogic(ctx context.Context, svcCtx *svc.ServiceContext) *GetN
 }
 
 func (l *GetNextNonceLogic) GetNextNonce(req *types.ReqGetNextNonce) (*types.NextNonce, error) {
-	bc := core.NewBlockChainForDryRun(l.svcCtx.AccountModel, l.svcCtx.LiquidityModel, l.svcCtx.NftModel,
+	bc, err := core.NewBlockChainForDryRun(l.svcCtx.AccountModel, l.svcCtx.LiquidityModel, l.svcCtx.NftModel,
 		l.svcCtx.TxPoolModel, l.svcCtx.AssetModel, l.svcCtx.SysConfigModel, l.svcCtx.RedisCache)
+	if err != nil {
+		return nil, err
+	}
 	nonce, err := bc.StateDB().GetPendingNonce(int64(req.AccountIndex))
 	if err != nil {
 		if err == types2.DbErrNotFound {

--- a/service/apiserver/internal/logic/transaction/sendtxlogic.go
+++ b/service/apiserver/internal/logic/transaction/sendtxlogic.go
@@ -31,7 +31,8 @@ func (s *SendTxLogic) SendTx(req *types.ReqSendTx) (resp *types.TxHash, err erro
 	bc, err := core.NewBlockChainForDryRun(s.svcCtx.AccountModel, s.svcCtx.LiquidityModel, s.svcCtx.NftModel, s.svcCtx.TxPoolModel,
 		s.svcCtx.AssetModel, s.svcCtx.SysConfigModel, s.svcCtx.RedisCache)
 	if err != nil {
-		return nil, err
+		logx.Error("fail to init blockchain runner:", err)
+		return nil, types2.AppErrInternal
 	}
 	newTx := &tx.Tx{
 		TxHash: types2.EmptyTxHash, // Would be computed in prepare method of executors.

--- a/service/apiserver/internal/logic/transaction/sendtxlogic.go
+++ b/service/apiserver/internal/logic/transaction/sendtxlogic.go
@@ -28,8 +28,11 @@ func NewSendTxLogic(ctx context.Context, svcCtx *svc.ServiceContext) *SendTxLogi
 
 func (s *SendTxLogic) SendTx(req *types.ReqSendTx) (resp *types.TxHash, err error) {
 	resp = &types.TxHash{}
-	bc := core.NewBlockChainForDryRun(s.svcCtx.AccountModel, s.svcCtx.LiquidityModel, s.svcCtx.NftModel, s.svcCtx.TxPoolModel,
+	bc, err := core.NewBlockChainForDryRun(s.svcCtx.AccountModel, s.svcCtx.LiquidityModel, s.svcCtx.NftModel, s.svcCtx.TxPoolModel,
 		s.svcCtx.AssetModel, s.svcCtx.SysConfigModel, s.svcCtx.RedisCache)
+	if err != nil {
+		return nil, err
+	}
 	newTx := &tx.Tx{
 		TxHash: types2.EmptyTxHash, // Would be computed in prepare method of executors.
 		TxType: int64(req.TxType),


### PR DESCRIPTION
### Description

Currently, `AccountMap`, `LiquidityMap`, and `NftMap` are used as caches in `StateDB`, but there is no elimination mechanism, and data will continue to accumulate as the system runs, eventually leading to out of memory.

### Rationale

Refactor the cache layer in `StateDB` and introduce `LRU` cache as the memory cache layer, which will automatically eliminate the data that has not been used recently. If it was missing in the cache layer, get it from the DB layer again.

### Example

N/A

### Changes

Notable changes:
* statedb, executors.