### PR TITLE
deployment: fix `make tools` naming conflict with folders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,3 +44,5 @@ build-only:
 docker-image:
 	go mod vendor # temporary, should be removed after open source
 	docker build . -t ${IMAGE_NAME}
+
+.PHONY: api-server deploy integration-test test tools build lint build-only docker-image


### PR DESCRIPTION
### Description

Add `.PHONY` to prevent naming conflict

### Rationale

The conflict error cause `make tools` failed

### Example

`make tools`

### Changes

NA