### PR TITLE
release: prepare for release v0.0.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,8 +87,8 @@ require (
 )
 
 require (
-	github.com/bnb-chain/zkbnb-crypto v0.0.6-0.20220920025959-19d5619a2719
-	github.com/bnb-chain/zkbnb-eth-rpc v0.0.2-0.20220920023706-21c047461c4b
+	github.com/bnb-chain/zkbnb-crypto v0.0.6
+	github.com/bnb-chain/zkbnb-eth-rpc v0.0.2
 	github.com/bnb-chain/zkbnb-smt v0.0.2-0.20220907130044-9c7cccbd19fa
 	github.com/consensys/gnark v0.7.0
 	github.com/consensys/gnark-crypto v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -117,10 +117,10 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwjwegp5jy4=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/zkbnb-crypto v0.0.6-0.20220920025959-19d5619a2719 h1:dX+MYBotuNgMiDMDdZH7vcnUvAdNlp8EoxWiBgcY3pc=
-github.com/bnb-chain/zkbnb-crypto v0.0.6-0.20220920025959-19d5619a2719/go.mod h1:SrKwMMrqi1Bxco6IYGXmqo7PvKVn3T3TuMMc7jD4LOA=
-github.com/bnb-chain/zkbnb-eth-rpc v0.0.2-0.20220920023706-21c047461c4b h1:xeh8XgyIXM5D4K+Sm1JpXs86IoRU2Ogwj4a5nlm+sZo=
-github.com/bnb-chain/zkbnb-eth-rpc v0.0.2-0.20220920023706-21c047461c4b/go.mod h1:T69T8enicQ5kSRPIzyPJv/jhuvRMz1UxsijPXmlis+I=
+github.com/bnb-chain/zkbnb-crypto v0.0.6 h1:UbD9XzTNQXfcEfI35MHbMMZ5IgqQFidYtvamAbHfS3o=
+github.com/bnb-chain/zkbnb-crypto v0.0.6/go.mod h1:SrKwMMrqi1Bxco6IYGXmqo7PvKVn3T3TuMMc7jD4LOA=
+github.com/bnb-chain/zkbnb-eth-rpc v0.0.2 h1:1rMa8XpplDNZaxeM1ifXMjSSeH/ucJyLUjHHEw1z4AA=
+github.com/bnb-chain/zkbnb-eth-rpc v0.0.2/go.mod h1:T69T8enicQ5kSRPIzyPJv/jhuvRMz1UxsijPXmlis+I=
 github.com/bnb-chain/zkbnb-smt v0.0.2-0.20220907130044-9c7cccbd19fa h1:aVqkz6Ge3eW7SKmINYMprpxq2VNpKp4vKQ6dEue8uUE=
 github.com/bnb-chain/zkbnb-smt v0.0.2-0.20220907130044-9c7cccbd19fa/go.mod h1:mGIAve72dt/VOVQ2wu7UjcjnMspnKczi5QACE1NGVec=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=


### PR DESCRIPTION
### Description
Release v0.0.3 is the baseline of performance improvement.

### Rationale
Update the crypto and eth0-rpc dependency to stable release 

/skip-integration-test

### Example
NA

### Changes

Notable changes:
NA