### PR TITLE
witness: pass state root when construct EmptyTx

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 )
 
 require (
-	github.com/bnb-chain/zkbnb-crypto v0.0.6
+	github.com/bnb-chain/zkbnb-crypto v0.0.6-0.20220926085300-2ef3bc0edb1d
 	github.com/bnb-chain/zkbnb-eth-rpc v0.0.2
 	github.com/bnb-chain/zkbnb-smt v0.0.2-0.20220907130044-9c7cccbd19fa
 	github.com/consensys/gnark v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwjwegp5jy4=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
+github.com/bnb-chain/zkbnb-crypto v0.0.6-0.20220926085300-2ef3bc0edb1d h1:G3bBPCMq6P0goJooTCOTS6MJ8Dp0CDDbW7SEDjtclZM=
+github.com/bnb-chain/zkbnb-crypto v0.0.6-0.20220926085300-2ef3bc0edb1d/go.mod h1:SrKwMMrqi1Bxco6IYGXmqo7PvKVn3T3TuMMc7jD4LOA=
 github.com/bnb-chain/zkbnb-crypto v0.0.6 h1:UbD9XzTNQXfcEfI35MHbMMZ5IgqQFidYtvamAbHfS3o=
 github.com/bnb-chain/zkbnb-crypto v0.0.6/go.mod h1:SrKwMMrqi1Bxco6IYGXmqo7PvKVn3T3TuMMc7jD4LOA=
 github.com/bnb-chain/zkbnb-eth-rpc v0.0.2 h1:1rMa8XpplDNZaxeM1ifXMjSSeH/ucJyLUjHHEw1z4AA=

--- a/service/witness/witness/witness.go
+++ b/service/witness/witness/witness.go
@@ -269,7 +269,7 @@ func (w *Witness) constructBlockWitness(block *block.Block, latestVerifiedBlockN
 
 	emptyTxCount := int(block.BlockSize) - len(block.Txs)
 	for i := 0; i < emptyTxCount; i++ {
-		txsWitness = append(txsWitness, circuit.EmptyTx())
+		txsWitness = append(txsWitness, circuit.EmptyTx(newStateRoot))
 	}
 	if common.Bytes2Hex(newStateRoot) != block.StateRoot {
 		return nil, errors.New("state root doesn't match")


### PR DESCRIPTION
### Description

see https://github.com/bnb-chain/zkbnb/issues/203 for detail

### Changes

Notable changes:
* change zkbnb-crypto version in go.mod
* pass state root when construct empty tx