### PR TITLE
feat(api.server): add `Size` member to `Block struct` for fullnode

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -595,6 +595,7 @@ Send raw transaction
 | verified_at | long |  | Yes |
 | txs | [ [Tx](#tx) ] |  | Yes |
 | status | long |  | Yes |
+| size | long |  | Yes |
 
 #### Blocks
 

--- a/service/apiserver/internal/logic/block/getblocklogic.go
+++ b/service/apiserver/internal/logic/block/getblocklogic.go
@@ -71,6 +71,7 @@ func (l *GetBlockLogic) GetBlock(req *types.ReqGetBlock) (resp *types.Block, err
 		VerifiedTxHash:                  block.VerifiedTxHash,
 		VerifiedAt:                      block.VerifiedAt,
 		Status:                          block.BlockStatus,
+		Size:                            block.BlockSize,
 	}
 	for _, dbTx := range block.Txs {
 		tx := utils.ConvertTx(dbTx)

--- a/service/apiserver/internal/logic/block/getblockslogic.go
+++ b/service/apiserver/internal/logic/block/getblockslogic.go
@@ -62,6 +62,7 @@ func (l *GetBlocksLogic) GetBlocks(req *types.ReqGetRange) (*types.Blocks, error
 			VerifiedTxHash:                  b.VerifiedTxHash,
 			VerifiedAt:                      b.VerifiedAt,
 			Status:                          b.BlockStatus,
+			Size:                            b.BlockSize,
 		}
 		for _, dbTx := range b.Txs {
 			tx := utils.ConvertTx(dbTx)

--- a/service/apiserver/server.api
+++ b/service/apiserver/server.api
@@ -144,6 +144,7 @@ type (
 		VerifiedAt                      int64  `json:"verified_at"`
 		Txs                             []*Tx  `json:"txs"`
 		Status                          int64  `json:"status"`
+		Size                            uint16 `json:"size"`
 	}
 
 	Blocks {

--- a/service/apiserver/test/getblock_test.go
+++ b/service/apiserver/test/getblock_test.go
@@ -36,6 +36,7 @@ func (s *ApiServerSuite) TestGetBlock() {
 				assert.NotNil(t, result.Height)
 				assert.NotNil(t, result.Commitment)
 				assert.NotNil(t, result.Status)
+				assert.NotNil(t, result.Size)
 				assert.NotNil(t, result.StateRoot)
 				fmt.Printf("result: %+v \n", result)
 			}

--- a/service/apiserver/test/getblocks_test.go
+++ b/service/apiserver/test/getblocks_test.go
@@ -38,6 +38,7 @@ func (s *ApiServerSuite) TestGetBlocks() {
 					assert.NotNil(t, result.Blocks[0].Height)
 					assert.NotNil(t, result.Blocks[0].Commitment)
 					assert.NotNil(t, result.Blocks[0].Status)
+					assert.NotNil(t, result.Blocks[0].Size)
 					assert.NotNil(t, result.Blocks[0].StateRoot)
 					//assert.NotNil(t, result.Blocks[0].Txs)
 				}


### PR DESCRIPTION
### Description

add Size for `type Block struct`

### Rationale

Sync l2 blocks from api server for FullNode, required block `Size` to create blocks into DB

### Changes

Notable changes:
* add Size member for type Block struct
* ...