### PR TITLE
feat: add icon url for assets

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -476,15 +476,16 @@ Send raw transaction
 
 #### Asset
 
-| Name         | Type | Description | Required |
-|--------------| ---- | ----------- | -------- |
+| Name         | Type    | Description | Required |
+|--------------|---------| ----------- | -------- |
 | id           | integer |  | Yes |
-| name         | string |  | Yes |
+| name         | string  |  | Yes |
 | decimals     | integer |  | Yes |
-| symbol       | string |  | Yes |
-| address      | string |  | Yes |
-| price        | string |  | Yes |
+| symbol       | string  |  | Yes |
+| address      | string  |  | Yes |
+| price        | string  |  | Yes |
 | is_gas_asset | integer |  | Yes |
+| icon         | string  |  | Yes |
 
 #### Assets
 

--- a/service/apiserver/internal/logic/asset/getassetlogic.go
+++ b/service/apiserver/internal/logic/asset/getassetlogic.go
@@ -2,6 +2,7 @@ package asset
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -15,6 +16,9 @@ import (
 const (
 	queryById     = "id"
 	queryBySymbol = "symbol"
+
+	// iconBaseUrl is used for showing icons for assets, asset owners should upload png files to the github repo
+	iconBaseUrl = "https://raw.githubusercontent.com/binance-chain/tokens-info/master/tokens/%s/%s.png"
 )
 
 type GetAssetLogic struct {
@@ -74,6 +78,7 @@ func (l *GetAssetLogic) GetAsset(req *types.ReqGetAsset) (resp *types.Asset, err
 		Address:    asset.L1Address,
 		Price:      strconv.FormatFloat(assetPrice, 'E', -1, 64),
 		IsGasAsset: asset.IsGasAsset,
+		Icon:       fmt.Sprintf(iconBaseUrl, strings.ToLower(asset.AssetSymbol), strings.ToLower(asset.AssetSymbol)),
 	}
 	return resp, nil
 }

--- a/service/apiserver/internal/logic/asset/getassetslogic.go
+++ b/service/apiserver/internal/logic/asset/getassetslogic.go
@@ -2,7 +2,9 @@ package asset
 
 import (
 	"context"
+	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/zeromicro/go-zero/core/logx"
 
@@ -60,6 +62,7 @@ func (l *GetAssetsLogic) GetAssets(req *types.ReqGetRange) (resp *types.Assets, 
 			Address:    asset.L1Address,
 			Price:      strconv.FormatFloat(assetPrice, 'E', -1, 64),
 			IsGasAsset: asset.IsGasAsset,
+			Icon:       fmt.Sprintf(iconBaseUrl, strings.ToLower(asset.AssetSymbol), strings.ToLower(asset.AssetSymbol)),
 		})
 	}
 	return resp, nil

--- a/service/apiserver/server.api
+++ b/service/apiserver/server.api
@@ -93,6 +93,7 @@ type (
 		Address    string `json:"address"`
 		Price      string `json:"price"`
 		IsGasAsset uint32 `json:"is_gas_asset"`
+		Icon       string `json:"icon"`
 	}
 
 	Assets {


### PR DESCRIPTION
### Description

Add icon url in asset related apis. The icon is from github; for token owners they should upload their logo files to this repo: https://github.com/bnb-chain/tokens-info

### Rationale

Enhance asset apis.

### Example

NA

### Changes

Notable changes:
* add `icon` field in asset apis