### PR TITLE
ci: install golangci-lint in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ tools:
 build: api-server build-only
 
 lint:
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.0
 	golangci-lint run ./...
 
 build-only:


### PR DESCRIPTION
### Description

Adding install of `golangci-lint` to the lint step in the Makefile

### Rationale

Noticed it wasn't installed in the Makefile.  

### Example

`make lint`
