### PR TITLE
committer: fix the bug when using new generated nft/account tx in the same block 

### DIFF
--- a/core/executor/deposit_executor.go
+++ b/core/executor/deposit_executor.go
@@ -44,7 +44,14 @@ func (e *DepositExecutor) Prepare() error {
 	account, err := bc.DB().AccountModel.GetAccountByNameHash(accountNameHash)
 	if err != nil {
 		exist := false
+		var newAccountIndexes []int64
 		for index := range bc.StateDB().PendingNewAccountMap {
+			newAccountIndexes = append(newAccountIndexes, index)
+		}
+		for index := range bc.StateDB().PendingUpdateAccountMap {
+			newAccountIndexes = append(newAccountIndexes, index)
+		}
+		for _, index := range newAccountIndexes {
 			tempAccount, err := bc.StateDB().GetAccount(index)
 			if err != nil {
 				continue

--- a/core/executor/deposit_nft_executor.go
+++ b/core/executor/deposit_nft_executor.go
@@ -44,7 +44,14 @@ func (e *DepositNftExecutor) Prepare() error {
 	account, err := bc.DB().AccountModel.GetAccountByNameHash(accountNameHash)
 	if err != nil {
 		exist := false
+		var newAccountIndexes []int64
 		for index := range bc.StateDB().PendingNewAccountMap {
+			newAccountIndexes = append(newAccountIndexes, index)
+		}
+		for index := range bc.StateDB().PendingUpdateAccountMap {
+			newAccountIndexes = append(newAccountIndexes, index)
+		}
+		for _, index := range newAccountIndexes {
 			tempAccount, err := bc.StateDB().GetAccount(index)
 			if err != nil {
 				continue

--- a/core/executor/full_exit_executor.go
+++ b/core/executor/full_exit_executor.go
@@ -44,7 +44,14 @@ func (e *FullExitExecutor) Prepare() error {
 	account, err := bc.DB().AccountModel.GetAccountByNameHash(accountNameHash)
 	if err != nil {
 		exist := false
+		var newAccountIndexes []int64
 		for index := range bc.StateDB().PendingNewAccountMap {
+			newAccountIndexes = append(newAccountIndexes, index)
+		}
+		for index := range bc.StateDB().PendingUpdateAccountMap {
+			newAccountIndexes = append(newAccountIndexes, index)
+		}
+		for _, index := range newAccountIndexes {
 			tempAccount, err := bc.StateDB().GetAccount(index)
 			if err != nil {
 				continue

--- a/core/executor/full_exit_nft_executor.go
+++ b/core/executor/full_exit_nft_executor.go
@@ -46,7 +46,14 @@ func (e *FullExitNftExecutor) Prepare() error {
 	account, err := bc.DB().AccountModel.GetAccountByNameHash(accountNameHash)
 	if err != nil {
 		exist := false
+		var newAccountIndexes []int64
 		for index := range bc.StateDB().PendingNewAccountMap {
+			newAccountIndexes = append(newAccountIndexes, index)
+		}
+		for index := range bc.StateDB().PendingUpdateAccountMap {
+			newAccountIndexes = append(newAccountIndexes, index)
+		}
+		for _, index := range newAccountIndexes {
 			tempAccount, err := bc.StateDB().GetAccount(index)
 			if err != nil {
 				continue

--- a/core/statedb/state_cache.go
+++ b/core/statedb/state_cache.go
@@ -107,6 +107,11 @@ func (c *StateCache) SetPendingNewAccount(accountIndex int64, account *types.Acc
 }
 
 func (c *StateCache) SetPendingUpdateAccount(accountIndex int64, account *types.AccountInfo) {
+	// TO confirm: why need a separate PendingNewAccount Map
+	_, exist := c.PendingNewAccountMap[accountIndex]
+	if exist {
+		delete(c.PendingNewAccountMap, accountIndex)
+	}
 	c.PendingUpdateAccountMap[accountIndex] = account
 }
 
@@ -115,5 +120,10 @@ func (c *StateCache) SetPendingNewNft(nftIndex int64, nft *nft.L2Nft) {
 }
 
 func (c *StateCache) SetPendingUpdateNft(nftIndex int64, nft *nft.L2Nft) {
+	// TO confirm: why need a separate PendingNewAccount Map
+	_, exist := c.PendingNewNftMap[nftIndex]
+	if exist {
+		delete(c.PendingNewNftMap, nftIndex)
+	}
 	c.PendingUpdateNftMap[nftIndex] = nft
 }

--- a/dao/account/account.go
+++ b/dao/account/account.go
@@ -181,7 +181,11 @@ func (m *defaultAccountModel) UpdateAccountsInTransact(tx *gorm.DB, accounts []*
 			return dbTx.Error
 		}
 		if dbTx.RowsAffected == 0 {
-			return types.DbErrFailToUpdateAccount
+			// this account is new, we need create first
+			dbTx = tx.Table(m.table).Create(&account)
+			if dbTx.Error != nil {
+				return dbTx.Error
+			}
 		}
 	}
 	return nil

--- a/dao/nft/nft.go
+++ b/dao/nft/nft.go
@@ -138,7 +138,10 @@ func (m *defaultL2NftModel) UpdateNftsInTransact(tx *gorm.DB, nfts []*L2Nft) err
 			return dbTx.Error
 		}
 		if dbTx.RowsAffected == 0 {
-			return types.DbErrFailToUpdateNft
+			dbTx = tx.Table(m.table).Create(&pendingNft)
+			if dbTx.Error != nil {
+				return dbTx.Error
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
### Description

When a block contains `mintNft`, `registerAccount` tx, `StateCache` will add an item in `PendingNewAccountMap` and `PendingNewNftMap`. And suppose there are other txs which uses the new generated account or nft in the same block, then `StateCache` will add an item in `PendingUpdateAccountMap` and `PendingUpdateNftMap`. When the block is committed (`commitNewBlock`), `StateDB` calls `GetNft` and `GetFormatAccount` which only return the new generated nft or account rather than updated nft or account.

### Rationale

### Example

### Changes

Notable changes:
* When there are update for new generated nft or account in the same block, then remove item in the `PendingNewAccountMap` and `PendingNewNftMap`

### Note
/update-integration-keyfile