### PR TITLE
core, dao: merge new update map for account and nft

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -169,25 +169,23 @@ func (bc *BlockChain) CommitNewBlock(blockSize int, createdAt int64) (*block.Blo
 		return nil, err
 	}
 
-	pendingNewAccount, pendingUpdateAccount, pendingNewAccountHistory, err := bc.Statedb.GetPendingAccount(currentHeight)
+	pendingAccount, pendingAccountHistory, err := bc.Statedb.GetPendingAccount(currentHeight)
 	if err != nil {
 		return nil, err
 	}
 
-	pendingNewNft, pendingUpdateNft, pendingNewNftHistory, err := bc.Statedb.GetPendingNft(currentHeight)
+	pendingNft, pendingNftHistory, err := bc.Statedb.GetPendingNft(currentHeight)
 	if err != nil {
 		return nil, err
 	}
 
 	return &block.BlockStates{
-		Block:                    newBlock,
-		CompressedBlock:          compressedBlock,
-		PendingNewAccount:        pendingNewAccount,
-		PendingUpdateAccount:     pendingUpdateAccount,
-		PendingNewAccountHistory: pendingNewAccountHistory,
-		PendingNewNft:            pendingNewNft,
-		PendingUpdateNft:         pendingUpdateNft,
-		PendingNewNftHistory:     pendingNewNftHistory,
+		Block:                 newBlock,
+		CompressedBlock:       compressedBlock,
+		PendingAccount:        pendingAccount,
+		PendingAccountHistory: pendingAccountHistory,
+		PendingNft:            pendingNft,
+		PendingNftHistory:     pendingNftHistory,
 	}, nil
 }
 

--- a/core/executor/atomic_match_executor.go
+++ b/core/executor/atomic_match_executor.go
@@ -215,11 +215,11 @@ func (e *AtomicMatchExecutor) ApplyTransaction() error {
 	matchNft.OwnerAccountIndex = txInfo.BuyOffer.AccountIndex
 
 	stateCache := e.bc.StateDB()
-	stateCache.SetPendingUpdateAccount(fromAccount.AccountIndex, fromAccount)
-	stateCache.SetPendingUpdateAccount(buyAccount.AccountIndex, buyAccount)
-	stateCache.SetPendingUpdateAccount(sellAccount.AccountIndex, sellAccount)
-	stateCache.SetPendingUpdateAccount(creatorAccount.AccountIndex, creatorAccount)
-	stateCache.SetPendingUpdateNft(matchNft.NftIndex, matchNft)
+	stateCache.SetPendingAccount(fromAccount.AccountIndex, fromAccount)
+	stateCache.SetPendingAccount(buyAccount.AccountIndex, buyAccount)
+	stateCache.SetPendingAccount(sellAccount.AccountIndex, sellAccount)
+	stateCache.SetPendingAccount(creatorAccount.AccountIndex, creatorAccount)
+	stateCache.SetPendingNft(matchNft.NftIndex, matchNft)
 	stateCache.SetPendingUpdateGas(txInfo.BuyOffer.AssetId, txInfo.TreasuryAmount)
 	stateCache.SetPendingUpdateGas(txInfo.GasFeeAssetId, txInfo.GasFeeAssetAmount)
 	return e.BaseExecutor.ApplyTransaction()

--- a/core/executor/cancel_offer_executor.go
+++ b/core/executor/cancel_offer_executor.go
@@ -93,7 +93,7 @@ func (e *CancelOfferExecutor) ApplyTransaction() error {
 	fromAccount.AssetInfo[offerAssetId].OfferCanceledOrFinalized = nOffer
 
 	stateCache := e.bc.StateDB()
-	stateCache.SetPendingUpdateAccount(fromAccount.AccountIndex, fromAccount)
+	stateCache.SetPendingAccount(fromAccount.AccountIndex, fromAccount)
 	stateCache.SetPendingUpdateGas(txInfo.GasFeeAssetId, txInfo.GasFeeAssetAmount)
 	return e.BaseExecutor.ApplyTransaction()
 }

--- a/core/executor/create_collection_executor.go
+++ b/core/executor/create_collection_executor.go
@@ -88,7 +88,7 @@ func (e *CreateCollectionExecutor) ApplyTransaction() error {
 	fromAccount.CollectionNonce++
 
 	stateCache := e.bc.StateDB()
-	stateCache.SetPendingUpdateAccount(fromAccount.AccountIndex, fromAccount)
+	stateCache.SetPendingAccount(fromAccount.AccountIndex, fromAccount)
 	stateCache.SetPendingUpdateGas(txInfo.GasFeeAssetId, txInfo.GasFeeAssetAmount)
 	return e.BaseExecutor.ApplyTransaction()
 }

--- a/core/executor/deposit_executor.go
+++ b/core/executor/deposit_executor.go
@@ -41,31 +41,9 @@ func (e *DepositExecutor) Prepare() error {
 
 	// The account index from txInfo isn't true, find account by account name hash.
 	accountNameHash := common.Bytes2Hex(txInfo.AccountNameHash)
-	account, err := bc.DB().AccountModel.GetAccountByNameHash(accountNameHash)
+	account, err := bc.StateDB().GetAccountByNameHash(accountNameHash)
 	if err != nil {
-		exist := false
-		var newAccountIndexes []int64
-		for index := range bc.StateDB().PendingNewAccountMap {
-			newAccountIndexes = append(newAccountIndexes, index)
-		}
-		for index := range bc.StateDB().PendingUpdateAccountMap {
-			newAccountIndexes = append(newAccountIndexes, index)
-		}
-		for _, index := range newAccountIndexes {
-			tempAccount, err := bc.StateDB().GetAccount(index)
-			if err != nil {
-				continue
-			}
-			if accountNameHash == tempAccount.AccountNameHash {
-				account = tempAccount
-				exist = true
-				break
-			}
-		}
-
-		if !exist {
-			return errors.New("invalid account name hash")
-		}
+		return err
 	}
 
 	// Set the right account index.
@@ -97,7 +75,7 @@ func (e *DepositExecutor) ApplyTransaction() error {
 	depositAccount.AssetInfo[txInfo.AssetId].Balance = ffmath.Add(depositAccount.AssetInfo[txInfo.AssetId].Balance, txInfo.AssetAmount)
 
 	stateCache := e.bc.StateDB()
-	stateCache.SetPendingUpdateAccount(depositAccount.AccountIndex, depositAccount)
+	stateCache.SetPendingAccount(depositAccount.AccountIndex, depositAccount)
 	return e.BaseExecutor.ApplyTransaction()
 }
 

--- a/core/executor/deposit_nft_executor.go
+++ b/core/executor/deposit_nft_executor.go
@@ -41,31 +41,9 @@ func (e *DepositNftExecutor) Prepare() error {
 
 	// The account index from txInfo isn't true, find account by account name hash.
 	accountNameHash := common.Bytes2Hex(txInfo.AccountNameHash)
-	account, err := bc.DB().AccountModel.GetAccountByNameHash(accountNameHash)
+	account, err := bc.StateDB().GetAccountByNameHash(accountNameHash)
 	if err != nil {
-		exist := false
-		var newAccountIndexes []int64
-		for index := range bc.StateDB().PendingNewAccountMap {
-			newAccountIndexes = append(newAccountIndexes, index)
-		}
-		for index := range bc.StateDB().PendingUpdateAccountMap {
-			newAccountIndexes = append(newAccountIndexes, index)
-		}
-		for _, index := range newAccountIndexes {
-			tempAccount, err := bc.StateDB().GetAccount(index)
-			if err != nil {
-				continue
-			}
-			if accountNameHash == tempAccount.AccountNameHash {
-				account = tempAccount
-				exist = true
-				break
-			}
-		}
-
-		if !exist {
-			return errors.New("invalid account name hash")
-		}
+		return err
 	}
 
 	// Set the right account index.
@@ -113,7 +91,7 @@ func (e *DepositNftExecutor) ApplyTransaction() error {
 	}
 
 	stateCache := e.bc.StateDB()
-	stateCache.SetPendingUpdateNft(txInfo.NftIndex, nft)
+	stateCache.SetPendingNft(txInfo.NftIndex, nft)
 	return e.BaseExecutor.ApplyTransaction()
 }
 

--- a/core/executor/full_exit_executor.go
+++ b/core/executor/full_exit_executor.go
@@ -41,31 +41,9 @@ func (e *FullExitExecutor) Prepare() error {
 
 	// The account index from txInfo isn't true, find account by account name hash.
 	accountNameHash := common.Bytes2Hex(txInfo.AccountNameHash)
-	account, err := bc.DB().AccountModel.GetAccountByNameHash(accountNameHash)
+	account, err := bc.StateDB().GetAccountByNameHash(accountNameHash)
 	if err != nil {
-		exist := false
-		var newAccountIndexes []int64
-		for index := range bc.StateDB().PendingNewAccountMap {
-			newAccountIndexes = append(newAccountIndexes, index)
-		}
-		for index := range bc.StateDB().PendingUpdateAccountMap {
-			newAccountIndexes = append(newAccountIndexes, index)
-		}
-		for _, index := range newAccountIndexes {
-			tempAccount, err := bc.StateDB().GetAccount(index)
-			if err != nil {
-				continue
-			}
-			if accountNameHash == tempAccount.AccountNameHash {
-				account = tempAccount
-				exist = true
-				break
-			}
-		}
-
-		if !exist {
-			return errors.New("invalid account name hash")
-		}
+		return err
 	}
 
 	// Set the right account index.
@@ -103,7 +81,7 @@ func (e *FullExitExecutor) ApplyTransaction() error {
 
 	if txInfo.AssetAmount.Cmp(types.ZeroBigInt) != 0 {
 		stateCache := e.bc.StateDB()
-		stateCache.SetPendingUpdateAccount(txInfo.AccountIndex, exitAccount)
+		stateCache.SetPendingAccount(txInfo.AccountIndex, exitAccount)
 	}
 	return e.BaseExecutor.ApplyTransaction()
 }

--- a/core/executor/full_exit_nft_executor.go
+++ b/core/executor/full_exit_nft_executor.go
@@ -44,31 +44,9 @@ func (e *FullExitNftExecutor) Prepare() error {
 
 	// The account index from txInfo isn't true, find account by account name hash.
 	accountNameHash := common.Bytes2Hex(txInfo.AccountNameHash)
-	account, err := bc.DB().AccountModel.GetAccountByNameHash(accountNameHash)
+	account, err := bc.StateDB().GetAccountByNameHash(accountNameHash)
 	if err != nil {
-		exist := false
-		var newAccountIndexes []int64
-		for index := range bc.StateDB().PendingNewAccountMap {
-			newAccountIndexes = append(newAccountIndexes, index)
-		}
-		for index := range bc.StateDB().PendingUpdateAccountMap {
-			newAccountIndexes = append(newAccountIndexes, index)
-		}
-		for _, index := range newAccountIndexes {
-			tempAccount, err := bc.StateDB().GetAccount(index)
-			if err != nil {
-				continue
-			}
-			if accountNameHash == tempAccount.AccountNameHash {
-				account = tempAccount
-				exist = true
-				break
-			}
-		}
-
-		if !exist {
-			return errors.New("invalid account name hash")
-		}
+		return err
 	}
 
 	// Set the right account index.
@@ -154,7 +132,7 @@ func (e *FullExitNftExecutor) ApplyTransaction() error {
 	}
 
 	stateCache := e.bc.StateDB()
-	stateCache.SetPendingUpdateNft(txInfo.NftIndex, emptyNft)
+	stateCache.SetPendingNft(txInfo.NftIndex, emptyNft)
 	return e.BaseExecutor.ApplyTransaction()
 }
 

--- a/core/executor/mint_nft_executor.go
+++ b/core/executor/mint_nft_executor.go
@@ -94,8 +94,8 @@ func (e *MintNftExecutor) ApplyTransaction() error {
 	creatorAccount.Nonce++
 
 	stateCache := e.bc.StateDB()
-	stateCache.SetPendingUpdateAccount(txInfo.CreatorAccountIndex, creatorAccount)
-	stateCache.SetPendingNewNft(txInfo.NftIndex, &nft.L2Nft{
+	stateCache.SetPendingAccount(txInfo.CreatorAccountIndex, creatorAccount)
+	stateCache.SetPendingNft(txInfo.NftIndex, &nft.L2Nft{
 		NftIndex:            txInfo.NftIndex,
 		CreatorAccountIndex: txInfo.CreatorAccountIndex,
 		OwnerAccountIndex:   txInfo.ToAccountIndex,

--- a/core/executor/register_zns_executor.go
+++ b/core/executor/register_zns_executor.go
@@ -5,10 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/zeromicro/go-zero/core/logx"
-	"github.com/zeromicro/go-zero/core/stores/sqlx"
-
 	"github.com/bnb-chain/zkbnb-crypto/wasm/txtypes"
 	common2 "github.com/bnb-chain/zkbnb/common"
 	"github.com/bnb-chain/zkbnb/common/chain"
@@ -16,6 +12,8 @@ import (
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/tree"
 	"github.com/bnb-chain/zkbnb/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/zeromicro/go-zero/core/logx"
 )
 
 type RegisterZnsExecutor struct {
@@ -52,19 +50,9 @@ func (e *RegisterZnsExecutor) VerifyInputs(skipGasAmtChk bool) error {
 	bc := e.bc
 	txInfo := e.txInfo
 
-	_, err := bc.DB().AccountModel.GetAccountByName(txInfo.AccountName)
-	if err != sqlx.ErrNotFound {
+	_, err := bc.StateDB().GetAccountByName(txInfo.AccountName)
+	if err == nil {
 		return errors.New("invalid account name, already registered")
-	}
-
-	for index := range bc.StateDB().PendingNewAccountMap {
-		account, err := bc.StateDB().GetFormatAccount(index)
-		if err != nil {
-			continue
-		}
-		if txInfo.AccountName == account.AccountName {
-			return errors.New("invalid account name, already registered")
-		}
 	}
 
 	if txInfo.AccountIndex != bc.StateDB().GetNextAccountIndex() {
@@ -99,7 +87,7 @@ func (e *RegisterZnsExecutor) ApplyTransaction() error {
 	bc.StateDB().AccountAssetTrees.UpdateCache(txInfo.AccountIndex, bc.CurrentBlock().BlockHeight)
 
 	stateCache := e.bc.StateDB()
-	stateCache.SetPendingNewAccount(txInfo.AccountIndex, formatAccount)
+	stateCache.SetPendingAccount(txInfo.AccountIndex, formatAccount)
 	return e.BaseExecutor.ApplyTransaction()
 }
 

--- a/core/executor/register_zns_executor.go
+++ b/core/executor/register_zns_executor.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/zeromicro/go-zero/core/logx"
+
 	"github.com/bnb-chain/zkbnb-crypto/wasm/txtypes"
 	common2 "github.com/bnb-chain/zkbnb/common"
 	"github.com/bnb-chain/zkbnb/common/chain"
@@ -12,8 +15,6 @@ import (
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/tree"
 	"github.com/bnb-chain/zkbnb/types"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/zeromicro/go-zero/core/logx"
 )
 
 type RegisterZnsExecutor struct {

--- a/core/executor/transfer_executor.go
+++ b/core/executor/transfer_executor.go
@@ -99,8 +99,8 @@ func (e *TransferExecutor) ApplyTransaction() error {
 	fromAccount.Nonce++
 
 	stateCache := e.bc.StateDB()
-	stateCache.SetPendingUpdateAccount(txInfo.FromAccountIndex, fromAccount)
-	stateCache.SetPendingUpdateAccount(txInfo.ToAccountIndex, toAccount)
+	stateCache.SetPendingAccount(txInfo.FromAccountIndex, fromAccount)
+	stateCache.SetPendingAccount(txInfo.ToAccountIndex, toAccount)
 	stateCache.SetPendingUpdateGas(txInfo.GasFeeAssetId, txInfo.GasFeeAssetAmount)
 	return e.BaseExecutor.ApplyTransaction()
 }

--- a/core/executor/transfer_nft_executor.go
+++ b/core/executor/transfer_nft_executor.go
@@ -103,8 +103,8 @@ func (e *TransferNftExecutor) ApplyTransaction() error {
 	nft.OwnerAccountIndex = txInfo.ToAccountIndex
 
 	stateCache := e.bc.StateDB()
-	stateCache.SetPendingUpdateAccount(txInfo.FromAccountIndex, fromAccount)
-	stateCache.SetPendingUpdateNft(txInfo.NftIndex, nft)
+	stateCache.SetPendingAccount(txInfo.FromAccountIndex, fromAccount)
+	stateCache.SetPendingNft(txInfo.NftIndex, nft)
 	stateCache.SetPendingUpdateGas(txInfo.GasFeeAssetId, txInfo.GasFeeAssetAmount)
 	return e.BaseExecutor.ApplyTransaction()
 }

--- a/core/executor/withdraw_executor.go
+++ b/core/executor/withdraw_executor.go
@@ -86,7 +86,7 @@ func (e *WithdrawExecutor) ApplyTransaction() error {
 	fromAccount.Nonce++
 
 	stateCache := e.bc.StateDB()
-	stateCache.SetPendingUpdateAccount(txInfo.FromAccountIndex, fromAccount)
+	stateCache.SetPendingAccount(txInfo.FromAccountIndex, fromAccount)
 	stateCache.SetPendingUpdateGas(txInfo.GasFeeAssetId, txInfo.GasFeeAssetAmount)
 	return e.BaseExecutor.ApplyTransaction()
 }

--- a/core/executor/withdraw_nft_executor.go
+++ b/core/executor/withdraw_nft_executor.go
@@ -122,8 +122,8 @@ func (e *WithdrawNftExecutor) ApplyTransaction() error {
 
 	newNftInfo := types.EmptyNftInfo(txInfo.NftIndex)
 	stateCache := e.bc.StateDB()
-	stateCache.SetPendingUpdateAccount(txInfo.AccountIndex, fromAccount)
-	stateCache.SetPendingUpdateNft(txInfo.NftIndex, &nft.L2Nft{
+	stateCache.SetPendingAccount(txInfo.AccountIndex, fromAccount)
+	stateCache.SetPendingNft(txInfo.NftIndex, &nft.L2Nft{
 		Model:               oldNft.Model,
 		NftIndex:            newNftInfo.NftIndex,
 		CreatorAccountIndex: newNftInfo.CreatorAccountIndex,

--- a/core/statedb/state_cache.go
+++ b/core/statedb/state_cache.go
@@ -23,11 +23,9 @@ type StateCache struct {
 	Txs                             []*tx.Tx
 
 	// Record the flat data that should be updated.
-	PendingNewAccountMap    map[int64]*types.AccountInfo
-	PendingNewNftMap        map[int64]*nft.L2Nft
-	PendingUpdateAccountMap map[int64]*types.AccountInfo
-	PendingUpdateNftMap     map[int64]*nft.L2Nft
-	PendingGasMap           map[int64]*big.Int //pending gas changes of a block
+	PendingAccountMap map[int64]*types.AccountInfo
+	PendingNftMap     map[int64]*nft.L2Nft
+	PendingGasMap     map[int64]*big.Int //pending gas changes of a block
 
 	// Record the tree states that should be updated.
 	dirtyAccountsAndAssetsMap map[int64]map[int64]bool
@@ -39,11 +37,9 @@ func NewStateCache(stateRoot string) *StateCache {
 		StateRoot: stateRoot,
 		Txs:       make([]*tx.Tx, 0),
 
-		PendingNewAccountMap:    make(map[int64]*types.AccountInfo, 0),
-		PendingNewNftMap:        make(map[int64]*nft.L2Nft, 0),
-		PendingUpdateAccountMap: make(map[int64]*types.AccountInfo, 0),
-		PendingUpdateNftMap:     make(map[int64]*nft.L2Nft, 0),
-		PendingGasMap:           make(map[int64]*big.Int, 0),
+		PendingAccountMap: make(map[int64]*types.AccountInfo, 0),
+		PendingNftMap:     make(map[int64]*nft.L2Nft, 0),
+		PendingGasMap:     make(map[int64]*big.Int, 0),
 
 		PubData:                         make([]byte, 0),
 		PriorityOperations:              0,
@@ -84,11 +80,7 @@ func (c *StateCache) MarkNftDirty(nftIndex int64) {
 }
 
 func (c *StateCache) GetPendingAccount(accountIndex int64) (*types.AccountInfo, bool) {
-	account, exist := c.PendingNewAccountMap[accountIndex]
-	if exist {
-		return account, exist
-	}
-	account, exist = c.PendingUpdateAccountMap[accountIndex]
+	account, exist := c.PendingAccountMap[accountIndex]
 	if exist {
 		return account, exist
 	}
@@ -96,41 +88,19 @@ func (c *StateCache) GetPendingAccount(accountIndex int64) (*types.AccountInfo, 
 }
 
 func (c *StateCache) GetPendingNft(nftIndex int64) (*nft.L2Nft, bool) {
-	nft, exist := c.PendingNewNftMap[nftIndex]
-	if exist {
-		return nft, exist
-	}
-	nft, exist = c.PendingUpdateNftMap[nftIndex]
+	nft, exist := c.PendingNftMap[nftIndex]
 	if exist {
 		return nft, exist
 	}
 	return nil, false
 }
 
-func (c *StateCache) SetPendingNewAccount(accountIndex int64, account *types.AccountInfo) {
-	c.PendingNewAccountMap[accountIndex] = account
+func (c *StateCache) SetPendingAccount(accountIndex int64, account *types.AccountInfo) {
+	c.PendingAccountMap[accountIndex] = account
 }
 
-func (c *StateCache) SetPendingUpdateAccount(accountIndex int64, account *types.AccountInfo) {
-	// TO confirm: why need a separate PendingNewAccount Map
-	_, exist := c.PendingNewAccountMap[accountIndex]
-	if exist {
-		delete(c.PendingNewAccountMap, accountIndex)
-	}
-	c.PendingUpdateAccountMap[accountIndex] = account
-}
-
-func (c *StateCache) SetPendingNewNft(nftIndex int64, nft *nft.L2Nft) {
-	c.PendingNewNftMap[nftIndex] = nft
-}
-
-func (c *StateCache) SetPendingUpdateNft(nftIndex int64, nft *nft.L2Nft) {
-	// TO confirm: why need a separate PendingNewAccount Map
-	_, exist := c.PendingNewNftMap[nftIndex]
-	if exist {
-		delete(c.PendingNewNftMap, nftIndex)
-	}
-	c.PendingUpdateNftMap[nftIndex] = nft
+func (c *StateCache) SetPendingNft(nftIndex int64, nft *nft.L2Nft) {
+	c.PendingNftMap[nftIndex] = nft
 }
 
 func (c *StateCache) GetPendingUpdateGas(assetId int64) *big.Int {

--- a/core/statedb/statedb.go
+++ b/core/statedb/statedb.go
@@ -194,17 +194,19 @@ func (s *StateDB) GetAccount(accountIndex int64) (*account.Account, error) {
 	return account, nil
 }
 
+// GetAccountByName get the account by its name.
+// Firstly, try to find the account in the current state cache, it iterates the pending
+// account map, not performance friendly, please take care when use this API.
+// Secondly, if not found in the current state cache, then try to find the account from database.
 func (s *StateDB) GetAccountByName(accountName string) (*account.Account, error) {
-	for accountIndex := range s.PendingAccountMap {
-		pending, exist := s.StateCache.GetPendingAccount(accountIndex)
-		if exist {
-			account, err := chain.FromFormatAccountInfo(pending)
+	for _, accountInfo := range s.PendingAccountMap {
+		if accountInfo.AccountName == accountName {
+			account, err := chain.FromFormatAccountInfo(accountInfo)
 			if err != nil {
 				return nil, err
 			}
-			if account.AccountName == accountName {
-				return account, nil
-			}
+
+			return account, nil
 		}
 	}
 
@@ -216,17 +218,19 @@ func (s *StateDB) GetAccountByName(accountName string) (*account.Account, error)
 	return account, nil
 }
 
+// GetAccountByNameHash get the account by its name hash.
+// Firstly, try to find the account in the current state cache, it iterates the pending
+// account map, not performance friendly, please take care when use this API.
+// Secondly, if not found in the current state cache, then try to find the account from database.
 func (s *StateDB) GetAccountByNameHash(accountNameHash string) (*account.Account, error) {
-	for accountIndex := range s.PendingAccountMap {
-		pending, exist := s.StateCache.GetPendingAccount(accountIndex)
-		if exist {
-			account, err := chain.FromFormatAccountInfo(pending)
+	for _, accountInfo := range s.PendingAccountMap {
+		if accountInfo.AccountNameHash == accountNameHash {
+			account, err := chain.FromFormatAccountInfo(accountInfo)
 			if err != nil {
 				return nil, err
 			}
-			if account.AccountNameHash == accountNameHash {
-				return account, nil
-			}
+
+			return account, nil
 		}
 	}
 

--- a/core/statedb/statedb.go
+++ b/core/statedb/statedb.go
@@ -194,6 +194,50 @@ func (s *StateDB) GetAccount(accountIndex int64) (*account.Account, error) {
 	return account, nil
 }
 
+func (s *StateDB) GetAccountByName(accountName string) (*account.Account, error) {
+	for accountIndex := range s.PendingAccountMap {
+		pending, exist := s.StateCache.GetPendingAccount(accountIndex)
+		if exist {
+			account, err := chain.FromFormatAccountInfo(pending)
+			if err != nil {
+				return nil, err
+			}
+			if account.AccountName == accountName {
+				return account, nil
+			}
+		}
+	}
+
+	account, err := s.chainDb.AccountModel.GetAccountByName(accountName)
+	if err != nil {
+		return nil, err
+	}
+
+	return account, nil
+}
+
+func (s *StateDB) GetAccountByNameHash(accountNameHash string) (*account.Account, error) {
+	for accountIndex := range s.PendingAccountMap {
+		pending, exist := s.StateCache.GetPendingAccount(accountIndex)
+		if exist {
+			account, err := chain.FromFormatAccountInfo(pending)
+			if err != nil {
+				return nil, err
+			}
+			if account.AccountNameHash == accountNameHash {
+				return account, nil
+			}
+		}
+	}
+
+	account, err := s.chainDb.AccountModel.GetAccountByNameHash(accountNameHash)
+	if err != nil {
+		return nil, err
+	}
+
+	return account, nil
+}
+
 func (s *StateDB) GetNft(nftIndex int64) (*nft.L2Nft, error) {
 	pending, exist := s.StateCache.GetPendingNft(nftIndex)
 	if exist {
@@ -256,22 +300,12 @@ func (s *StateDB) SyncPendingGasAccount() error {
 }
 
 func (s *StateDB) SyncStateCacheToRedis() error {
-	// Sync new create to cache.
-	err := s.syncPendingAccount(s.PendingNewAccountMap)
+	// Sync pending to cache.
+	err := s.syncPendingAccount(s.PendingAccountMap)
 	if err != nil {
 		return err
 	}
-	err = s.syncPendingNft(s.PendingNewNftMap)
-	if err != nil {
-		return err
-	}
-
-	// Sync pending update to cache.
-	err = s.syncPendingAccount(s.PendingUpdateAccountMap)
-	if err != nil {
-		return err
-	}
-	err = s.syncPendingNft(s.PendingUpdateNftMap)
+	err = s.syncPendingNft(s.PendingNftMap)
 	if err != nil {
 		return err
 	}
@@ -283,27 +317,9 @@ func (s *StateDB) PurgeCache(stateRoot string) {
 	s.StateCache = NewStateCache(stateRoot)
 }
 
-func (s *StateDB) GetPendingAccount(blockHeight int64) ([]*account.Account, []*account.Account, []*account.AccountHistory, error) {
-	pendingNewAccount := make([]*account.Account, 0)
-	pendingUpdateAccount := make([]*account.Account, 0)
-	pendingNewAccountHistory := make([]*account.AccountHistory, 0)
-
-	for _, formatAccount := range s.PendingNewAccountMap {
-		newAccount, err := chain.FromFormatAccountInfo(formatAccount)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-
-		pendingNewAccount = append(pendingNewAccount, newAccount)
-		pendingNewAccountHistory = append(pendingNewAccountHistory, &account.AccountHistory{
-			AccountIndex:    newAccount.AccountIndex,
-			Nonce:           newAccount.Nonce,
-			CollectionNonce: newAccount.CollectionNonce,
-			AssetInfo:       newAccount.AssetInfo,
-			AssetRoot:       newAccount.AssetRoot,
-			L2BlockHeight:   blockHeight, // TODO: ensure this should be the new block's height.
-		})
-	}
+func (s *StateDB) GetPendingAccount(blockHeight int64) ([]*account.Account, []*account.AccountHistory, error) {
+	pendingAccount := make([]*account.Account, 0)
+	pendingAccountHistory := make([]*account.AccountHistory, 0)
 
 	gasChanged := false
 	for _, delta := range s.StateCache.PendingGasMap {
@@ -314,11 +330,7 @@ func (s *StateDB) GetPendingAccount(blockHeight int64) ([]*account.Account, []*a
 	}
 
 	handledGasAccount := false
-	for index, formatAccount := range s.PendingUpdateAccountMap {
-		if _, exist := s.PendingNewAccountMap[index]; exist {
-			continue
-		}
-
+	for _, formatAccount := range s.PendingAccountMap {
 		if formatAccount.AccountIndex == types.GasAccount && gasChanged {
 			handledGasAccount = true
 			s.applyGasUpdate(formatAccount)
@@ -326,11 +338,10 @@ func (s *StateDB) GetPendingAccount(blockHeight int64) ([]*account.Account, []*a
 
 		newAccount, err := chain.FromFormatAccountInfo(formatAccount)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
-
-		pendingUpdateAccount = append(pendingUpdateAccount, newAccount)
-		pendingNewAccountHistory = append(pendingNewAccountHistory, &account.AccountHistory{
+		pendingAccount = append(pendingAccount, newAccount)
+		pendingAccountHistory = append(pendingAccountHistory, &account.AccountHistory{
 			AccountIndex:    newAccount.AccountIndex,
 			Nonce:           newAccount.Nonce,
 			CollectionNonce: newAccount.CollectionNonce,
@@ -343,22 +354,22 @@ func (s *StateDB) GetPendingAccount(blockHeight int64) ([]*account.Account, []*a
 	if !handledGasAccount && gasChanged {
 		gasAccount, err := s.GetAccount(types.GasAccount)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
 
 		formatAccount, err := chain.ToFormatAccountInfo(gasAccount)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
 		s.applyGasUpdate(formatAccount)
 
 		newAccount, err := chain.FromFormatAccountInfo(formatAccount)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
 
-		pendingUpdateAccount = append(pendingUpdateAccount, newAccount)
-		pendingNewAccountHistory = append(pendingNewAccountHistory, &account.AccountHistory{
+		pendingAccount = append(pendingAccount, newAccount)
+		pendingAccountHistory = append(pendingAccountHistory, &account.AccountHistory{
 			AccountIndex:    newAccount.AccountIndex,
 			Nonce:           newAccount.Nonce,
 			CollectionNonce: newAccount.CollectionNonce,
@@ -368,7 +379,7 @@ func (s *StateDB) GetPendingAccount(blockHeight int64) ([]*account.Account, []*a
 		})
 	}
 
-	return pendingNewAccount, pendingUpdateAccount, pendingNewAccountHistory, nil
+	return pendingAccount, pendingAccountHistory, nil
 }
 
 func (s *StateDB) applyGasUpdate(formatAccount *types.AccountInfo) {
@@ -384,14 +395,13 @@ func (s *StateDB) applyGasUpdate(formatAccount *types.AccountInfo) {
 	}
 }
 
-func (s *StateDB) GetPendingNft(blockHeight int64) ([]*nft.L2Nft, []*nft.L2Nft, []*nft.L2NftHistory, error) {
-	pendingNewNft := make([]*nft.L2Nft, 0)
-	pendingUpdateNft := make([]*nft.L2Nft, 0)
-	pendingNewNftHistory := make([]*nft.L2NftHistory, 0)
+func (s *StateDB) GetPendingNft(blockHeight int64) ([]*nft.L2Nft, []*nft.L2NftHistory, error) {
+	pendingNft := make([]*nft.L2Nft, 0)
+	pendingNftHistory := make([]*nft.L2NftHistory, 0)
 
-	for _, newNft := range s.PendingNewNftMap {
-		pendingNewNft = append(pendingNewNft, newNft)
-		pendingNewNftHistory = append(pendingNewNftHistory, &nft.L2NftHistory{
+	for _, newNft := range s.PendingNftMap {
+		pendingNft = append(pendingNft, newNft)
+		pendingNftHistory = append(pendingNftHistory, &nft.L2NftHistory{
 			NftIndex:            newNft.NftIndex,
 			CreatorAccountIndex: newNft.CreatorAccountIndex,
 			OwnerAccountIndex:   newNft.OwnerAccountIndex,
@@ -404,25 +414,7 @@ func (s *StateDB) GetPendingNft(blockHeight int64) ([]*nft.L2Nft, []*nft.L2Nft, 
 		})
 	}
 
-	for index, newNft := range s.PendingUpdateNftMap {
-		if _, exist := s.PendingNewNftMap[index]; exist {
-			continue
-		}
-		pendingUpdateNft = append(pendingUpdateNft, newNft)
-		pendingNewNftHistory = append(pendingNewNftHistory, &nft.L2NftHistory{
-			NftIndex:            newNft.NftIndex,
-			CreatorAccountIndex: newNft.CreatorAccountIndex,
-			OwnerAccountIndex:   newNft.OwnerAccountIndex,
-			NftContentHash:      newNft.NftContentHash,
-			NftL1Address:        newNft.NftL1Address,
-			NftL1TokenId:        newNft.NftL1TokenId,
-			CreatorTreasuryRate: newNft.CreatorTreasuryRate,
-			CollectionId:        newNft.CollectionId,
-			L2BlockHeight:       blockHeight,
-		})
-	}
-
-	return pendingNewNft, pendingUpdateNft, pendingNewNftHistory, nil
+	return pendingNft, pendingNftHistory, nil
 }
 
 func (s *StateDB) DeepCopyAccounts(accountIds []int64) (map[int64]*types.AccountInfo, error) {
@@ -637,16 +629,12 @@ func (s *StateDB) GetNextAccountIndex() int64 {
 }
 
 func (s *StateDB) GetNextNftIndex() int64 {
-	if len(s.PendingNewNftMap) == 0 {
-		maxNftIndex, err := s.chainDb.L2NftModel.GetLatestNftIndex()
-		if err != nil {
-			panic("get latest nft index error: " + err.Error())
-		}
-		return maxNftIndex + 1
+	maxNftIndex, err := s.chainDb.L2NftModel.GetLatestNftIndex()
+	if err != nil {
+		panic("get latest nft index error: " + err.Error())
 	}
 
-	maxNftIndex := int64(-1)
-	for index := range s.PendingNewNftMap {
+	for index := range s.PendingNftMap {
 		if index > maxNftIndex {
 			maxNftIndex = index
 		}

--- a/dao/account/account.go
+++ b/dao/account/account.go
@@ -43,7 +43,6 @@ type (
 		GetAccountByNameHash(nameHash string) (account *Account, err error)
 		GetAccounts(limit int, offset int64) (accounts []*Account, err error)
 		GetAccountsTotalCount() (count int64, err error)
-		CreateAccountsInTransact(tx *gorm.DB, accounts []*Account) error
 		UpdateAccountsInTransact(tx *gorm.DB, accounts []*Account) error
 	}
 
@@ -159,17 +158,6 @@ func (m *defaultAccountModel) GetConfirmedAccountByIndex(accountIndex int64) (ac
 		return nil, types.DbErrNotFound
 	}
 	return account, nil
-}
-
-func (m *defaultAccountModel) CreateAccountsInTransact(tx *gorm.DB, accounts []*Account) error {
-	dbTx := tx.Table(m.table).CreateInBatches(accounts, len(accounts))
-	if dbTx.Error != nil {
-		return dbTx.Error
-	}
-	if dbTx.RowsAffected != int64(len(accounts)) {
-		return types.DbErrFailToCreateAccount
-	}
-	return nil
 }
 
 func (m *defaultAccountModel) UpdateAccountsInTransact(tx *gorm.DB, accounts []*Account) error {

--- a/dao/block/block.go
+++ b/dao/block/block.go
@@ -89,12 +89,10 @@ type (
 		Block           *Block
 		CompressedBlock *compressedblock.CompressedBlock
 
-		PendingNewAccount        []*account.Account
-		PendingUpdateAccount     []*account.Account
-		PendingNewAccountHistory []*account.AccountHistory
-		PendingNewNft            []*nft.L2Nft
-		PendingUpdateNft         []*nft.L2Nft
-		PendingNewNftHistory     []*nft.L2NftHistory
+		PendingAccount        []*account.Account
+		PendingAccountHistory []*account.AccountHistory
+		PendingNft            []*nft.L2Nft
+		PendingNftHistory     []*nft.L2NftHistory
 	}
 )
 

--- a/dao/nft/nft.go
+++ b/dao/nft/nft.go
@@ -35,7 +35,6 @@ type (
 		GetLatestNftIndex() (nftIndex int64, err error)
 		GetNftsByAccountIndex(accountIndex, limit, offset int64) (nfts []*L2Nft, err error)
 		GetNftsCountByAccountIndex(accountIndex int64) (int64, error)
-		CreateNftsInTransact(tx *gorm.DB, nfts []*L2Nft) error
 		UpdateNftsInTransact(tx *gorm.DB, nfts []*L2Nft) error
 	}
 	defaultL2NftModel struct {
@@ -116,17 +115,6 @@ func (m *defaultL2NftModel) GetNftsCountByAccountIndex(accountIndex int64) (int6
 		return 0, types.DbErrNotFound
 	}
 	return count, nil
-}
-
-func (m *defaultL2NftModel) CreateNftsInTransact(tx *gorm.DB, nfts []*L2Nft) error {
-	dbTx := tx.Table(m.table).CreateInBatches(nfts, len(nfts))
-	if dbTx.Error != nil {
-		return dbTx.Error
-	}
-	if dbTx.RowsAffected != int64(len(nfts)) {
-		return types.DbErrFailToCreateNft
-	}
-	return nil
 }
 
 func (m *defaultL2NftModel) UpdateNftsInTransact(tx *gorm.DB, nfts []*L2Nft) error {

--- a/service/committer/committer/committer.go
+++ b/service/committer/committer/committer.go
@@ -274,44 +274,30 @@ func (c *Committer) commitNewBlock(curBlock *block.Block) (*block.Block, error) 
 				return err
 			}
 		}
-		// create new account
-		if len(blockStates.PendingNewAccount) != 0 {
-			err = c.bc.DB().AccountModel.CreateAccountsInTransact(tx, blockStates.PendingNewAccount)
+		// create or update account
+		if len(blockStates.PendingAccount) != 0 {
+			err = c.bc.DB().AccountModel.UpdateAccountsInTransact(tx, blockStates.PendingAccount)
 			if err != nil {
 				return err
 			}
 		}
-		// update account
-		if len(blockStates.PendingUpdateAccount) != 0 {
-			err = c.bc.DB().AccountModel.UpdateAccountsInTransact(tx, blockStates.PendingUpdateAccount)
+		// create account history
+		if len(blockStates.PendingAccountHistory) != 0 {
+			err = c.bc.DB().AccountHistoryModel.CreateAccountHistoriesInTransact(tx, blockStates.PendingAccountHistory)
 			if err != nil {
 				return err
 			}
 		}
-		// create new account history
-		if len(blockStates.PendingNewAccountHistory) != 0 {
-			err = c.bc.DB().AccountHistoryModel.CreateAccountHistoriesInTransact(tx, blockStates.PendingNewAccountHistory)
+		// create or update nft
+		if len(blockStates.PendingNft) != 0 {
+			err = c.bc.DB().L2NftModel.UpdateNftsInTransact(tx, blockStates.PendingNft)
 			if err != nil {
 				return err
 			}
 		}
-		// create new nft
-		if len(blockStates.PendingNewNft) != 0 {
-			err = c.bc.DB().L2NftModel.CreateNftsInTransact(tx, blockStates.PendingNewNft)
-			if err != nil {
-				return err
-			}
-		}
-		// update nft
-		if len(blockStates.PendingUpdateNft) != 0 {
-			err = c.bc.DB().L2NftModel.UpdateNftsInTransact(tx, blockStates.PendingUpdateNft)
-			if err != nil {
-				return err
-			}
-		}
-		// new nft history
-		if len(blockStates.PendingNewNftHistory) != 0 {
-			err = c.bc.DB().L2NftHistoryModel.CreateNftHistoriesInTransact(tx, blockStates.PendingNewNftHistory)
+		// create nft history
+		if len(blockStates.PendingNftHistory) != 0 {
+			err = c.bc.DB().L2NftHistoryModel.CreateNftHistoriesInTransact(tx, blockStates.PendingNftHistory)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### Description

1. Merge the pending new account and update account.
2. Merge the pending new nft and update nft.

### Rationale

There is no need to use two different maps for the new and update operations, using one we can realize the same function, and the logic is simpler.

### Example

NA

### Changes

Notable changes:
* Merge new and update map for account and nft.