### PR TITLE
sender: fix corner case in case the rollup tx is timeout

### DIFF
--- a/dao/l1rolluptx/l1_rollup_tx.go
+++ b/dao/l1rolluptx/l1_rollup_tx.go
@@ -43,6 +43,7 @@ type (
 		GetLatestHandledTx(txType int64) (tx *L1RollupTx, err error)
 		GetLatestPendingTx(txType int64) (tx *L1RollupTx, err error)
 		GetL1RollupTxsByStatus(txStatus int) (txs []*L1RollupTx, err error)
+		GetL1RollupTxsByHash(hash string) (txs []*L1RollupTx, err error)
 		DeleteL1RollupTx(tx *L1RollupTx) error
 		UpdateL1RollupTxsInTransact(tx *gorm.DB, txs []*L1RollupTx) error
 	}
@@ -96,6 +97,16 @@ func (m *defaultL1RollupTxModel) CreateL1RollupTx(tx *L1RollupTx) error {
 
 func (m *defaultL1RollupTxModel) GetL1RollupTxsByStatus(txStatus int) (txs []*L1RollupTx, err error) {
 	dbTx := m.DB.Table(m.table).Where("tx_status = ?", txStatus).Order("l2_block_height, tx_type").Find(&txs)
+	if dbTx.Error != nil {
+		return nil, types.DbErrSqlOperation
+	} else if dbTx.RowsAffected == 0 {
+		return nil, types.DbErrNotFound
+	}
+	return txs, nil
+}
+
+func (m *defaultL1RollupTxModel) GetL1RollupTxsByHash(hash string) (txs []*L1RollupTx, err error) {
+	dbTx := m.DB.Table(m.table).Where("l1_tx_hash = ?", hash).Find(&txs)
 	if dbTx.Error != nil {
 		return nil, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {

--- a/service/monitor/monitor/monitor.go
+++ b/service/monitor/monitor/monitor.go
@@ -18,6 +18,7 @@ package monitor
 
 import (
 	"fmt"
+	"github.com/bnb-chain/zkbnb/dao/proof"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/zeromicro/go-zero/core/logx"
@@ -65,6 +66,7 @@ type Monitor struct {
 	TxPoolModel          tx.TxPoolModel
 	SysConfigModel       sysconfig.SysConfigModel
 	L1RollupTxModel      l1rolluptx.L1RollupTxModel
+	ProofModel           proof.ProofModel
 	L2AssetModel         asset.AssetModel
 	PriorityRequestModel priorityrequest.PriorityRequestModel
 	L1SyncedBlockModel   l1syncedblock.L1SyncedBlockModel
@@ -83,6 +85,7 @@ func NewMonitor(c config.Config) *Monitor {
 		TxPoolModel:          tx.NewTxPoolModel(db),
 		BlockModel:           block.NewBlockModel(db),
 		L1RollupTxModel:      l1rolluptx.NewL1RollupTxModel(db),
+		ProofModel:           proof.NewProofModel(db),
 		L1SyncedBlockModel:   l1syncedblock.NewL1SyncedBlockModel(db),
 		L2AssetModel:         asset.NewAssetModel(db),
 		SysConfigModel:       sysconfig.NewSysConfigModel(db),

--- a/service/monitor/monitor/monitor.go
+++ b/service/monitor/monitor/monitor.go
@@ -18,7 +18,6 @@ package monitor
 
 import (
 	"fmt"
-	"github.com/bnb-chain/zkbnb/dao/proof"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/zeromicro/go-zero/core/logx"
@@ -32,6 +31,7 @@ import (
 	"github.com/bnb-chain/zkbnb/dao/l1rolluptx"
 	"github.com/bnb-chain/zkbnb/dao/l1syncedblock"
 	"github.com/bnb-chain/zkbnb/dao/priorityrequest"
+	"github.com/bnb-chain/zkbnb/dao/proof"
 	"github.com/bnb-chain/zkbnb/dao/sysconfig"
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/service/monitor/config"

--- a/service/monitor/monitor/monitor_generic_blocks.go
+++ b/service/monitor/monitor/monitor_generic_blocks.go
@@ -190,6 +190,7 @@ func (m *Monitor) MonitorGenericBlocks() (err error) {
 		for _, val := range pendingUpdateCommittedBlocks {
 			_, err = m.L1RollupTxModel.GetL1RollupTxsByHash(val.CommittedTxHash)
 			if err == types2.DbErrNotFound {
+				logx.Info("monitor create commit rollup tx ", val.CommittedTxHash, val.BlockHeight)
 				// the rollup tx is deleted by sender
 				// so we insert it here
 				err = m.L1RollupTxModel.CreateL1RollupTx(&l1rolluptx.L1RollupTx{
@@ -209,6 +210,7 @@ func (m *Monitor) MonitorGenericBlocks() (err error) {
 		for _, val := range pendingUpdateVerifiedBlocks {
 			_, err = m.L1RollupTxModel.GetL1RollupTxsByHash(val.VerifiedTxHash)
 			if err == types2.DbErrNotFound {
+				logx.Info("monitor create verify rollup tx ", val.VerifiedTxHash, val.BlockHeight)
 				// the rollup tx is deleted by sender
 				// so we insert it here
 				err = m.L1RollupTxModel.CreateL1RollupTx(&l1rolluptx.L1RollupTx{

--- a/service/monitor/monitor/monitor_generic_blocks.go
+++ b/service/monitor/monitor/monitor_generic_blocks.go
@@ -156,15 +156,29 @@ func (m *Monitor) MonitorGenericBlocks() (err error) {
 
 	// get pending update blocks
 	pendingUpdateBlocks := make([]*block.Block, 0, len(relatedBlocks))
-	pendingUpdateCommittedBlocks := make([]*block.Block, 0)
-	pendingUpdateVerifiedBlocks := make([]*block.Block, 0)
+	pendingUpdateCommittedBlocks := make(map[string]*block.Block, 0)
+	pendingUpdateVerifiedBlocks := make(map[string]*block.Block, 0)
 	for _, pendingUpdateBlock := range relatedBlocks {
 		pendingUpdateBlocks = append(pendingUpdateBlocks, pendingUpdateBlock)
 		if pendingUpdateBlock.CommittedTxHash != "" {
-			pendingUpdateCommittedBlocks = append(pendingUpdateCommittedBlocks, pendingUpdateBlock)
+			b, exist := pendingUpdateCommittedBlocks[pendingUpdateBlock.CommittedTxHash]
+			if exist {
+				if b.BlockHeight < pendingUpdateBlock.BlockHeight {
+					pendingUpdateCommittedBlocks[pendingUpdateBlock.CommittedTxHash] = pendingUpdateBlock
+				}
+			} else {
+				pendingUpdateCommittedBlocks[pendingUpdateBlock.CommittedTxHash] = pendingUpdateBlock
+			}
 		}
 		if pendingUpdateBlock.VerifiedTxHash != "" {
-			pendingUpdateVerifiedBlocks = append(pendingUpdateVerifiedBlocks, pendingUpdateBlock)
+			b, exist := pendingUpdateVerifiedBlocks[pendingUpdateBlock.VerifiedTxHash]
+			if exist {
+				if b.BlockHeight < pendingUpdateBlock.BlockHeight {
+					pendingUpdateVerifiedBlocks[pendingUpdateBlock.VerifiedTxHash] = pendingUpdateBlock
+				}
+			} else {
+				pendingUpdateVerifiedBlocks[pendingUpdateBlock.VerifiedTxHash] = pendingUpdateBlock
+			}
 		}
 	}
 

--- a/service/sender/sender/sender.go
+++ b/service/sender/sender/sender.go
@@ -184,7 +184,7 @@ func (s *Sender) CommitBlocks() (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to create tx in database, err: %v", err)
 	}
-	logx.Infof("new blocks have been committed(height): %v", newRollupTx.L2BlockHeight)
+	logx.Infof("new blocks have been committed(height): %v:%s", newRollupTx.L2BlockHeight, newRollupTx.L1TxHash)
 	return nil
 }
 
@@ -368,7 +368,7 @@ func (s *Sender) VerifyAndExecuteBlocks() (err error) {
 	if err != nil {
 		return fmt.Errorf(fmt.Sprintf("failed to create rollup tx in db %v", err))
 	}
-	logx.Infof("new blocks have been verified and executed(height): %d", newRollupTx.L2BlockHeight)
+	logx.Infof("new blocks have been verified and executed(height): %d:%s", newRollupTx.L2BlockHeight, newRollupTx.L1TxHash)
 	return nil
 }
 

--- a/service/sender/sender/sender.go
+++ b/service/sender/sender/sender.go
@@ -322,7 +322,7 @@ func (s *Sender) VerifyAndExecuteBlocks() (err error) {
 		return errors.New("related proofs not ready")
 	}
 	// add sanity check
-	for i, _ := range blockProofs {
+	for i := range blockProofs {
 		if blockProofs[i].BlockNumber != blocks[i].BlockHeight {
 			return errors.New("proof number not match")
 		}

--- a/service/sender/sender/sender.go
+++ b/service/sender/sender/sender.go
@@ -172,7 +172,7 @@ func (s *Sender) CommitBlocks() (err error) {
 		gasPrice,
 		s.config.ChainConfig.GasLimit)
 	if err != nil {
-		return fmt.Errorf("failed to send commit tx, errL %v", err)
+		return fmt.Errorf("failed to send commit tx, errL %v:%s", err, txHash)
 	}
 	newRollupTx := &l1rolluptx.L1RollupTx{
 		L1TxHash:      txHash,
@@ -355,7 +355,7 @@ func (s *Sender) VerifyAndExecuteBlocks() (err error) {
 	txHash, err := zkbnb.VerifyAndExecuteBlocks(cli, authCli, zkbnbInstance,
 		pendingVerifyAndExecuteBlocks, proofs, gasPrice, s.config.ChainConfig.GasLimit)
 	if err != nil {
-		return fmt.Errorf("failed to send verify tx: %v", err)
+		return fmt.Errorf("failed to send verify tx: %v:%s", err, txHash)
 	}
 
 	newRollupTx := &l1rolluptx.L1RollupTx{


### PR DESCRIPTION
### Description

When sender can't find l1 rollup txs receipt in `MaxWaitingTime`,  then sender would delete the l1 rollup txs from table, and resend a new rollup tx. But there is such a situation that the old l1 rollup tx is already on-chain and successful, thus the resent tx would fail.

### Rationale

### Example

### Changes

Notable changes:
* monitor can changes rollup tx status in case that sender delete the successful rollup tx.

### Note
/update-integration-keyfile