### PR TITLE
feat: export toAccountIndex and toAccountName in Tx APIs

### DIFF
--- a/service/apiserver/internal/logic/transaction/getaccountpendingtxslogic.go
+++ b/service/apiserver/internal/logic/transaction/getaccountpendingtxslogic.go
@@ -65,6 +65,9 @@ func (l *GetAccountPendingTxsLogic) GetAccountPendingTxs(req *types.ReqGetAccoun
 		tx := utils.ConvertTx(poolTx)
 		tx.AccountName, _ = l.svcCtx.MemCache.GetAccountNameByIndex(tx.AccountIndex)
 		tx.AssetName, _ = l.svcCtx.MemCache.GetAssetNameById(tx.AssetId)
+		if tx.ToAccountIndex >= 0 {
+			tx.ToAccountName, _ = l.svcCtx.MemCache.GetAccountNameByIndex(tx.ToAccountIndex)
+		}
 		resp.Txs = append(resp.Txs, tx)
 	}
 	return resp, nil

--- a/service/apiserver/internal/logic/transaction/getaccounttxslogic.go
+++ b/service/apiserver/internal/logic/transaction/getaccounttxslogic.go
@@ -78,6 +78,9 @@ func (l *GetAccountTxsLogic) GetAccountTxs(req *types.ReqGetAccountTxs) (resp *t
 		tx := utils.ConvertTx(dbTx)
 		tx.AccountName, _ = l.svcCtx.MemCache.GetAccountNameByIndex(tx.AccountIndex)
 		tx.AssetName, _ = l.svcCtx.MemCache.GetAssetNameById(tx.AssetId)
+		if tx.ToAccountIndex >= 0 {
+			tx.ToAccountName, _ = l.svcCtx.MemCache.GetAccountNameByIndex(tx.ToAccountIndex)
+		}
 		resp.Txs = append(resp.Txs, tx)
 	}
 	return resp, nil

--- a/service/apiserver/internal/logic/transaction/getblocktxslogic.go
+++ b/service/apiserver/internal/logic/transaction/getblocktxslogic.go
@@ -68,6 +68,9 @@ func (l *GetBlockTxsLogic) GetBlockTxs(req *types.ReqGetBlockTxs) (resp *types.T
 		tx := utils.ConvertTx(dbTx)
 		tx.AccountName, _ = l.svcCtx.MemCache.GetAccountNameByIndex(tx.AccountIndex)
 		tx.AssetName, _ = l.svcCtx.MemCache.GetAssetNameById(tx.AssetId)
+		if tx.ToAccountIndex >= 0 {
+			tx.ToAccountName, _ = l.svcCtx.MemCache.GetAccountNameByIndex(tx.ToAccountIndex)
+		}
 		resp.Txs = append(resp.Txs, tx)
 	}
 	return resp, nil

--- a/service/apiserver/internal/logic/transaction/getpendingtxslogic.go
+++ b/service/apiserver/internal/logic/transaction/getpendingtxslogic.go
@@ -48,6 +48,9 @@ func (l *GetPendingTxsLogic) GetPendingTxs(req *types.ReqGetRange) (*types.Txs, 
 		tx := utils.ConvertTx(pendingTx)
 		tx.AccountName, _ = l.svcCtx.MemCache.GetAccountNameByIndex(tx.AccountIndex)
 		tx.AssetName, _ = l.svcCtx.MemCache.GetAssetNameById(tx.AssetId)
+		if tx.ToAccountIndex >= 0 {
+			tx.ToAccountName, _ = l.svcCtx.MemCache.GetAccountNameByIndex(tx.ToAccountIndex)
+		}
 		resp.Txs = append(resp.Txs, tx)
 	}
 	return resp, nil

--- a/service/apiserver/internal/logic/transaction/gettxlogic.go
+++ b/service/apiserver/internal/logic/transaction/gettxlogic.go
@@ -34,6 +34,9 @@ func (l *GetTxLogic) GetTx(req *types.ReqGetTx) (resp *types.EnrichedTx, err err
 		resp.Tx = *utils.ConvertTx(tx)
 		resp.Tx.AccountName, _ = l.svcCtx.MemCache.GetAccountNameByIndex(tx.AccountIndex)
 		resp.Tx.AssetName, _ = l.svcCtx.MemCache.GetAssetNameById(tx.AssetId)
+		if resp.Tx.ToAccountIndex >= 0 {
+			resp.Tx.ToAccountName, _ = l.svcCtx.MemCache.GetAccountNameByIndex(resp.Tx.ToAccountIndex)
+		}
 		block, err := l.svcCtx.MemCache.GetBlockByHeightWithFallback(tx.BlockHeight, func() (interface{}, error) {
 			return l.svcCtx.BlockModel.GetBlockByHeight(resp.Tx.BlockHeight)
 		})
@@ -56,6 +59,9 @@ func (l *GetTxLogic) GetTx(req *types.ReqGetTx) (resp *types.EnrichedTx, err err
 		resp.Tx = *utils.ConvertTx(poolTx)
 		resp.Tx.AccountName, _ = l.svcCtx.MemCache.GetAccountNameByIndex(poolTx.AccountIndex)
 		resp.Tx.AssetName, _ = l.svcCtx.MemCache.GetAssetNameById(poolTx.AssetId)
+		if resp.Tx.ToAccountIndex >= 0 {
+			resp.Tx.ToAccountName, _ = l.svcCtx.MemCache.GetAccountNameByIndex(resp.Tx.ToAccountIndex)
+		}
 	}
 
 	return resp, nil

--- a/service/apiserver/internal/logic/transaction/gettxslogic.go
+++ b/service/apiserver/internal/logic/transaction/gettxslogic.go
@@ -49,6 +49,9 @@ func (l *GetTxsLogic) GetTxs(req *types.ReqGetRange) (resp *types.Txs, err error
 		tx := utils.ConvertTx(dbTx)
 		tx.AccountName, _ = l.svcCtx.MemCache.GetAccountNameByIndex(tx.AccountIndex)
 		tx.AssetName, _ = l.svcCtx.MemCache.GetAssetNameById(tx.AssetId)
+		if tx.ToAccountIndex >= 0 {
+			tx.ToAccountName, _ = l.svcCtx.MemCache.GetAccountNameByIndex(tx.ToAccountIndex)
+		}
 		resp.Txs = append(resp.Txs, tx)
 	}
 

--- a/service/apiserver/internal/logic/utils/converter.go
+++ b/service/apiserver/internal/logic/utils/converter.go
@@ -3,28 +3,57 @@ package utils
 import (
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/service/apiserver/internal/types"
+	types2 "github.com/bnb-chain/zkbnb/types"
+	"github.com/zeromicro/go-zero/core/logx"
 )
 
 func ConvertTx(tx *tx.Tx) *types.Tx {
+	toAccountIndex := int64(-1)
+
+	switch tx.TxType {
+	case types2.TxTypeMintNft:
+		txInfo, err := types2.ParseMintNftTxInfo(tx.TxInfo)
+		if err != nil {
+			logx.Errorf("parse mintNft tx failed: %s", err.Error())
+		} else {
+			toAccountIndex = txInfo.ToAccountIndex
+		}
+	case types2.TxTypeTransfer:
+		txInfo, err := types2.ParseTransferTxInfo(tx.TxInfo)
+		if err != nil {
+			logx.Errorf("parse transfer tx failed: %s", err.Error())
+		} else {
+			toAccountIndex = txInfo.ToAccountIndex
+		}
+	case types2.TxTypeTransferNft:
+		txInfo, err := types2.ParseTransferNftTxInfo(tx.TxInfo)
+		if err != nil {
+			logx.Errorf("parse transferNft tx failed: %s", err.Error())
+		} else {
+			toAccountIndex = txInfo.ToAccountIndex
+		}
+	}
+
 	return &types.Tx{
-		Hash:          tx.TxHash,
-		Type:          tx.TxType,
-		GasFee:        tx.GasFee,
-		GasFeeAssetId: tx.GasFeeAssetId,
-		Status:        int64(tx.TxStatus),
-		Index:         tx.TxIndex,
-		BlockHeight:   tx.BlockHeight,
-		NftIndex:      tx.NftIndex,
-		CollectionId:  tx.CollectionId,
-		AssetId:       tx.AssetId,
-		Amount:        tx.TxAmount,
-		NativeAddress: tx.NativeAddress,
-		Info:          tx.TxInfo,
-		ExtraInfo:     tx.ExtraInfo,
-		Memo:          tx.Memo,
-		AccountIndex:  tx.AccountIndex,
-		Nonce:         tx.Nonce,
-		ExpiredAt:     tx.ExpiredAt,
-		CreatedAt:     tx.CreatedAt.Unix(),
+		Hash:           tx.TxHash,
+		Type:           tx.TxType,
+		GasFee:         tx.GasFee,
+		GasFeeAssetId:  tx.GasFeeAssetId,
+		Status:         int64(tx.TxStatus),
+		Index:          tx.TxIndex,
+		BlockHeight:    tx.BlockHeight,
+		NftIndex:       tx.NftIndex,
+		CollectionId:   tx.CollectionId,
+		AssetId:        tx.AssetId,
+		Amount:         tx.TxAmount,
+		NativeAddress:  tx.NativeAddress,
+		Info:           tx.TxInfo,
+		ExtraInfo:      tx.ExtraInfo,
+		Memo:           tx.Memo,
+		AccountIndex:   tx.AccountIndex,
+		Nonce:          tx.Nonce,
+		ExpiredAt:      tx.ExpiredAt,
+		CreatedAt:      tx.CreatedAt.Unix(),
+		ToAccountIndex: toAccountIndex,
 	}
 }

--- a/service/apiserver/server.api
+++ b/service/apiserver/server.api
@@ -256,28 +256,30 @@ service server-api {
 
 type (
 	Tx {
-		Hash          string `json:"hash"`
-		Type          int64  `json:"type,range=[1:64]"`
-		Amount        string `json:"amount"`
-		Info          string `json:"info"`
-		Status        int64  `json:"status"`
-		Index         int64  `json:"index"`
-		GasFeeAssetId int64  `json:"gas_fee_asset_id"`
-		GasFee        string `json:"gas_fee"`
-		NftIndex      int64  `json:"nft_index"`
-		CollectionId  int64  `json:"collection_id"`
-		AssetId       int64  `json:"asset_id"`
-		AssetName     string `json:"asset_name"`
-		NativeAddress string `json:"native_address"`
-		ExtraInfo     string `json:"extra_info"`
-		Memo          string `json:"memo"`
-		AccountIndex  int64  `json:"account_index"`
-		AccountName   string `json:"account_name"`
-		Nonce         int64  `json:"nonce"`
-		ExpiredAt     int64  `json:"expire_at"`
-		BlockHeight   int64  `json:"block_height"`
-		CreatedAt     int64  `json:"created_at"`
-		StateRoot     string `json:"state_root"`
+		Hash           string `json:"hash"`
+		Type           int64  `json:"type,range=[1:64]"`
+		Amount         string `json:"amount"`
+		Info           string `json:"info"`
+		Status         int64  `json:"status"`
+		Index          int64  `json:"index"`
+		GasFeeAssetId  int64  `json:"gas_fee_asset_id"`
+		GasFee         string `json:"gas_fee"`
+		NftIndex       int64  `json:"nft_index"`
+		CollectionId   int64  `json:"collection_id"`
+		AssetId        int64  `json:"asset_id"`
+		AssetName      string `json:"asset_name"`
+		NativeAddress  string `json:"native_address"`
+		ExtraInfo      string `json:"extra_info"`
+		Memo           string `json:"memo"`
+		AccountIndex   int64  `json:"account_index"`
+		AccountName    string `json:"account_name"`
+		Nonce          int64  `json:"nonce"`
+		ExpiredAt      int64  `json:"expire_at"`
+		BlockHeight    int64  `json:"block_height"`
+		CreatedAt      int64  `json:"created_at"`
+		StateRoot      string `json:"state_root"`
+		ToAccountIndex int64  `json:"to_account_index"`
+		ToAccountName  string `json:"to_account_name"`
 	}
 
 	Txs {


### PR DESCRIPTION
### Description

Export `to_account_index` and `to_account_name` in Tx APIs.
The two fields are meaningful only when the tx type is transfer/transferNft/MintNft.

### Rationale

zkWallet frontend need the fields in tx

### Example

GET /api/v1/tx?hash=xxx

Response:
```
{
  "hash": ...,
  "type": 7 // mint NFT
  ......
  "to_account_index": 2, // new field
  "to_account_name": "test.lengend" // new field
}
```

### Changes
N/A