### PR TITLE
feat: support query account tx APIs by txType

### DIFF
--- a/dao/tx/tx.go
+++ b/dao/tx/tx.go
@@ -39,14 +39,14 @@ const (
 )
 
 type getTxOption struct {
-	Type *int64
+	Types []int64
 }
 
 type GetTxOptionFunc func(*getTxOption)
 
-func GetTxWithType(txType int64) GetTxOptionFunc {
+func GetTxWithTypes(txTypes []int64) GetTxOptionFunc {
 	return func(o *getTxOption) {
-		o.Type = &txType
+		o.Types = txTypes
 	}
 }
 
@@ -146,8 +146,8 @@ func (m *defaultTxModel) GetTxsByAccountIndex(accountIndex int64, limit int64, o
 	}
 
 	dbTx := m.DB.Table(m.table).Where("account_index = ?", accountIndex)
-	if opt.Type != nil {
-		dbTx = dbTx.Where("tx_type = ?", *opt.Type)
+	if len(opt.Types) > 0 {
+		dbTx = dbTx.Where("tx_type IN ?", opt.Types)
 	}
 
 	dbTx = dbTx.Limit(int(limit)).Offset(int(offset)).Order("created_at desc").Find(&txList)
@@ -166,8 +166,8 @@ func (m *defaultTxModel) GetTxsCountByAccountIndex(accountIndex int64, options .
 	}
 
 	dbTx := m.DB.Table(m.table).Where("account_index = ?", accountIndex)
-	if opt.Type != nil {
-		dbTx = dbTx.Where("tx_type = ?", *opt.Type)
+	if len(opt.Types) > 0 {
+		dbTx = dbTx.Where("tx_type IN ?", opt.Types)
 	}
 
 	dbTx = dbTx.Count(&count)

--- a/dao/tx/tx_pool.go
+++ b/dao/tx/tx_pool.go
@@ -129,8 +129,8 @@ func (m *defaultTxPoolModel) GetPendingTxsByAccountIndex(accountIndex int64, opt
 	}
 
 	dbTx := m.DB.Table(m.table).Where("tx_status = ? AND account_index = ?", StatusPending, accountIndex)
-	if opt.Type != nil {
-		dbTx = dbTx.Where("tx_type = ?", *opt.Type)
+	if len(opt.Types) > 0 {
+		dbTx = dbTx.Where("tx_type IN ?", opt.Types)
 	}
 
 	dbTx = dbTx.Order("created_at, id").Find(&txs)

--- a/service/apiserver/internal/logic/transaction/getaccountpendingtxslogic.go
+++ b/service/apiserver/internal/logic/transaction/getaccountpendingtxslogic.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/zeromicro/go-zero/core/logx"
 
+	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/service/apiserver/internal/logic/utils"
 	"github.com/bnb-chain/zkbnb/service/apiserver/internal/svc"
 	"github.com/bnb-chain/zkbnb/service/apiserver/internal/types"
@@ -53,7 +54,12 @@ func (l *GetAccountPendingTxsLogic) GetAccountPendingTxs(req *types.ReqGetAccoun
 		return nil, types2.AppErrInternal
 	}
 
-	poolTxs, err := l.svcCtx.TxPoolModel.GetPendingTxsByAccountIndex(accountIndex)
+	options := []tx.GetTxOptionFunc{}
+	if req.Type != nil {
+		options = append(options, tx.GetTxWithType(int64(*req.Type)))
+	}
+
+	poolTxs, err := l.svcCtx.TxPoolModel.GetPendingTxsByAccountIndex(accountIndex, options...)
 	if err != nil {
 		if err != types2.DbErrNotFound {
 			return nil, types2.AppErrInternal

--- a/service/apiserver/internal/logic/transaction/getaccountpendingtxslogic.go
+++ b/service/apiserver/internal/logic/transaction/getaccountpendingtxslogic.go
@@ -55,8 +55,8 @@ func (l *GetAccountPendingTxsLogic) GetAccountPendingTxs(req *types.ReqGetAccoun
 	}
 
 	options := []tx.GetTxOptionFunc{}
-	if req.Type != nil {
-		options = append(options, tx.GetTxWithType(int64(*req.Type)))
+	if len(req.Types) > 0 {
+		options = append(options, tx.GetTxWithTypes(req.Types))
 	}
 
 	poolTxs, err := l.svcCtx.TxPoolModel.GetPendingTxsByAccountIndex(accountIndex, options...)

--- a/service/apiserver/internal/logic/transaction/getaccounttxslogic.go
+++ b/service/apiserver/internal/logic/transaction/getaccounttxslogic.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/zeromicro/go-zero/core/logx"
 
+	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/service/apiserver/internal/logic/utils"
 	"github.com/bnb-chain/zkbnb/service/apiserver/internal/svc"
 	"github.com/bnb-chain/zkbnb/service/apiserver/internal/types"
@@ -59,7 +60,12 @@ func (l *GetAccountTxsLogic) GetAccountTxs(req *types.ReqGetAccountTxs) (resp *t
 		return nil, types2.AppErrInternal
 	}
 
-	total, err := l.svcCtx.TxModel.GetTxsCountByAccountIndex(accountIndex)
+	options := []tx.GetTxOptionFunc{}
+	if req.Type != nil {
+		options = append(options, tx.GetTxWithType(int64(*req.Type)))
+	}
+
+	total, err := l.svcCtx.TxModel.GetTxsCountByAccountIndex(accountIndex, options...)
 	if err != nil {
 		return nil, types2.AppErrInternal
 	}
@@ -69,7 +75,7 @@ func (l *GetAccountTxsLogic) GetAccountTxs(req *types.ReqGetAccountTxs) (resp *t
 		return resp, nil
 	}
 
-	txs, err := l.svcCtx.TxModel.GetTxsByAccountIndex(accountIndex, int64(req.Limit), int64(req.Offset))
+	txs, err := l.svcCtx.TxModel.GetTxsByAccountIndex(accountIndex, int64(req.Limit), int64(req.Offset), options...)
 	if err != nil {
 		return nil, types2.AppErrInternal
 	}

--- a/service/apiserver/internal/logic/transaction/getaccounttxslogic.go
+++ b/service/apiserver/internal/logic/transaction/getaccounttxslogic.go
@@ -61,8 +61,8 @@ func (l *GetAccountTxsLogic) GetAccountTxs(req *types.ReqGetAccountTxs) (resp *t
 	}
 
 	options := []tx.GetTxOptionFunc{}
-	if req.Type != nil {
-		options = append(options, tx.GetTxWithType(int64(*req.Type)))
+	if len(req.Types) > 0 {
+		options = append(options, tx.GetTxWithTypes(req.Types))
 	}
 
 	total, err := l.svcCtx.TxModel.GetTxsCountByAccountIndex(accountIndex, options...)

--- a/service/apiserver/server.api
+++ b/service/apiserver/server.api
@@ -308,10 +308,11 @@ type (
 	}
 
 	ReqGetAccountTxs {
-		By     string `form:"by,options=account_index|account_name|account_pk"`
-		Value  string `form:"value"`
-		Offset uint16 `form:"offset,range=[0:100000]"`
-		Limit  uint16 `form:"limit,range=[1:100]"`
+		By     string  `form:"by,options=account_index|account_name|account_pk"`
+		Value  string  `form:"value"`
+		Type   *uint32 `form:"type,optional"`
+		Offset uint16  `form:"offset,range=[0:100000]"`
+		Limit  uint16  `form:"limit,range=[1:100]"`
 	}
 
 	ReqGetTx {
@@ -324,8 +325,9 @@ type (
 	}
 
 	ReqGetAccountPendingTxs {
-		By    string `form:"by,options=account_index|account_name|account_pk"`
-		Value string `form:"value"`
+		By    string  `form:"by,options=account_index|account_name|account_pk"`
+		Value string  `form:"value"`
+		Type  *uint32 `form:"type,optional"`
 	}
 
 	ReqGetNextNonce {

--- a/service/apiserver/server.api
+++ b/service/apiserver/server.api
@@ -310,7 +310,7 @@ type (
 	ReqGetAccountTxs {
 		By     string  `form:"by,options=account_index|account_name|account_pk"`
 		Value  string  `form:"value"`
-		Type   *uint32 `form:"type,optional"`
+		Types  []int64 `form:"types,optional"`
 		Offset uint16  `form:"offset,range=[0:100000]"`
 		Limit  uint16  `form:"limit,range=[1:100]"`
 	}
@@ -327,7 +327,7 @@ type (
 	ReqGetAccountPendingTxs {
 		By    string  `form:"by,options=account_index|account_name|account_pk"`
 		Value string  `form:"value"`
-		Type  *uint32 `form:"type,optional"`
+		Types []int64 `form:"types,optional"`
 	}
 
 	ReqGetNextNonce {

--- a/service/apiserver/test/getaccountpendingtxs_test.go
+++ b/service/apiserver/test/getaccountpendingtxs_test.go
@@ -17,7 +17,7 @@ func (s *ApiServerSuite) TestGetAccountPoolTxs() {
 	type args struct {
 		by      string
 		value   string
-		txTypes []int
+		txTypes []int64
 	}
 
 	type testcase struct {
@@ -33,15 +33,15 @@ func (s *ApiServerSuite) TestGetAccountPoolTxs() {
 		{"invalidby", args{"invalidby", "", nil}, 400},
 	}
 
-	txType := 7
 	statusCode, txs := GetPendingTxs(s, 0, 100)
 	if statusCode == http.StatusOK && len(txs.Txs) > 0 {
-		_, account := GetAccount(s, "name", txs.Txs[len(txs.Txs)-1].AccountName)
+		tx := txs.Txs[len(txs.Txs)-1]
+		_, account := GetAccount(s, "name", tx.AccountName)
 		tests = append(tests, []testcase{
 			{"found by index", args{"account_index", strconv.Itoa(int(account.Index)), nil}, 200},
 			{"found by name", args{"account_name", account.Name, nil}, 200},
 			{"found by pk", args{"account_pk", account.Pk, nil}, 200},
-			{"found by index and type", args{"account_index", strconv.Itoa(int(account.Index)), []int{txType}}, 200},
+			{"found by index and type", args{"account_index", strconv.Itoa(int(account.Index)), []int64{tx.Type}}, 200},
 		}...)
 	}
 
@@ -66,7 +66,7 @@ func (s *ApiServerSuite) TestGetAccountPoolTxs() {
 
 }
 
-func GetAccountPendingTxs(s *ApiServerSuite, by, value string, txTypes []int) (int, *types.Txs) {
+func GetAccountPendingTxs(s *ApiServerSuite, by, value string, txTypes []int64) (int, *types.Txs) {
 	url := fmt.Sprintf("%s/api/v1/accountPendingTxs?by=%s&value=%s", s.url, by, value)
 	for _, t := range txTypes {
 		url += fmt.Sprintf("&types[]=%d", t)

--- a/service/apiserver/test/getaccountpendingtxs_test.go
+++ b/service/apiserver/test/getaccountpendingtxs_test.go
@@ -15,9 +15,9 @@ import (
 
 func (s *ApiServerSuite) TestGetAccountPoolTxs() {
 	type args struct {
-		by     string
-		value  string
-		txType *int
+		by      string
+		value   string
+		txTypes []int
 	}
 
 	type testcase struct {
@@ -41,13 +41,13 @@ func (s *ApiServerSuite) TestGetAccountPoolTxs() {
 			{"found by index", args{"account_index", strconv.Itoa(int(account.Index)), nil}, 200},
 			{"found by name", args{"account_name", account.Name, nil}, 200},
 			{"found by pk", args{"account_pk", account.Pk, nil}, 200},
-			{"found by index and type", args{"account_index", strconv.Itoa(int(account.Index)), &txType}, 200},
+			{"found by index and type", args{"account_index", strconv.Itoa(int(account.Index)), []int{txType}}, 200},
 		}...)
 	}
 
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
-			httpCode, result := GetAccountPendingTxs(s, tt.args.by, tt.args.value, tt.args.txType)
+			httpCode, result := GetAccountPendingTxs(s, tt.args.by, tt.args.value, tt.args.txTypes)
 			assert.Equal(t, tt.httpCode, httpCode)
 			if httpCode == http.StatusOK {
 				if result.Total > 0 {
@@ -66,10 +66,10 @@ func (s *ApiServerSuite) TestGetAccountPoolTxs() {
 
 }
 
-func GetAccountPendingTxs(s *ApiServerSuite, by, value string, txType *int) (int, *types.Txs) {
+func GetAccountPendingTxs(s *ApiServerSuite, by, value string, txTypes []int) (int, *types.Txs) {
 	url := fmt.Sprintf("%s/api/v1/accountPendingTxs?by=%s&value=%s", s.url, by, value)
-	if txType != nil {
-		url += fmt.Sprintf("&type=%d", *txType)
+	for _, t := range txTypes {
+		url += fmt.Sprintf("&types[]=%d", t)
 	}
 	resp, err := http.Get(url)
 	assert.NoError(s.T(), err)

--- a/service/apiserver/test/getaccountpendingtxs_test.go
+++ b/service/apiserver/test/getaccountpendingtxs_test.go
@@ -42,6 +42,7 @@ func (s *ApiServerSuite) TestGetAccountPoolTxs() {
 			{"found by name", args{"account_name", account.Name, nil}, 200},
 			{"found by pk", args{"account_pk", account.Pk, nil}, 200},
 			{"found by index and type", args{"account_index", strconv.Itoa(int(account.Index)), []int64{tx.Type}}, 200},
+			{"not found by index and type", args{"account_index", strconv.Itoa(int(account.Index)), []int64{10000}}, 200},
 		}...)
 	}
 
@@ -68,8 +69,9 @@ func (s *ApiServerSuite) TestGetAccountPoolTxs() {
 
 func GetAccountPendingTxs(s *ApiServerSuite, by, value string, txTypes []int64) (int, *types.Txs) {
 	url := fmt.Sprintf("%s/api/v1/accountPendingTxs?by=%s&value=%s", s.url, by, value)
-	for _, t := range txTypes {
-		url += fmt.Sprintf("&types[]=%d", t)
+	if len(txTypes) > 0 {
+		data, _ := json.Marshal(txTypes)
+		url += fmt.Sprintf("&types=%s", string(data))
 	}
 	resp, err := http.Get(url)
 	assert.NoError(s.T(), err)

--- a/service/apiserver/test/getaccounttxs_test.go
+++ b/service/apiserver/test/getaccounttxs_test.go
@@ -15,11 +15,11 @@ import (
 
 func (s *ApiServerSuite) TestGetAccountTxs() {
 	type args struct {
-		by     string
-		value  string
-		offset int
-		limit  int
-		txType *int
+		by      string
+		value   string
+		offset  int
+		limit   int
+		txTypes []int
 	}
 
 	type testcase struct {
@@ -43,13 +43,13 @@ func (s *ApiServerSuite) TestGetAccountTxs() {
 			{"found by index", args{"account_index", strconv.Itoa(int(account.Index)), 0, 10, nil}, 200},
 			{"found by name", args{"account_name", account.Name, 0, 10, nil}, 200},
 			{"found by pk", args{"account_pk", account.Pk, 0, 10, nil}, 200},
-			{"found by index and type", args{"account_index", strconv.Itoa(int(account.Index)), 0, 10, &txType}, 200},
+			{"found by index and type", args{"account_index", strconv.Itoa(int(account.Index)), 0, 10, []int{txType}}, 200},
 		}...)
 	}
 
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
-			httpCode, result := GetAccountTxs(s, tt.args.by, tt.args.value, tt.args.offset, tt.args.limit, tt.args.txType)
+			httpCode, result := GetAccountTxs(s, tt.args.by, tt.args.value, tt.args.offset, tt.args.limit, tt.args.txTypes)
 			assert.Equal(t, tt.httpCode, httpCode)
 			if httpCode == http.StatusOK {
 				if tt.args.offset < int(result.Total) {
@@ -68,10 +68,10 @@ func (s *ApiServerSuite) TestGetAccountTxs() {
 
 }
 
-func GetAccountTxs(s *ApiServerSuite, by, value string, offset, limit int, txType *int) (int, *types.Txs) {
+func GetAccountTxs(s *ApiServerSuite, by, value string, offset, limit int, txTypes []int) (int, *types.Txs) {
 	url := fmt.Sprintf("%s/api/v1/accountTxs?by=%s&value=%s&offset=%d&limit=%d", s.url, by, value, offset, limit)
-	if txType != nil {
-		url += fmt.Sprintf("&type=%d", *txType)
+	for _, t := range txTypes {
+		url += fmt.Sprintf("&types[]=%d", t)
 	}
 	resp, err := http.Get(url)
 	assert.NoError(s.T(), err)

--- a/service/apiserver/test/getaccounttxs_test.go
+++ b/service/apiserver/test/getaccounttxs_test.go
@@ -19,6 +19,7 @@ func (s *ApiServerSuite) TestGetAccountTxs() {
 		value  string
 		offset int
 		limit  int
+		txType *int
 	}
 
 	type testcase struct {
@@ -28,25 +29,27 @@ func (s *ApiServerSuite) TestGetAccountTxs() {
 	}
 
 	tests := []testcase{
-		{"not found by index", args{"account_index", "99999999", 0, 10}, 200},
-		{"not found by name", args{"account_name", "fakeaccount.legend", 0, 10}, 200},
-		{"not found by pk", args{"account_pk", "fake8470d33c59a5cbf5e10df426eb97c2773ab890c3364f4162ba782a56ca998", 0, 10}, 200},
-		{"invalid by", args{"invalidby", "fake8470d33c59a5cbf5e10df426eb97c2773ab890c3364f4162ba782a56ca998", 0, 10}, 400},
+		{"not found by index", args{"account_index", "99999999", 0, 10, nil}, 200},
+		{"not found by name", args{"account_name", "fakeaccount.legend", 0, 10, nil}, 200},
+		{"not found by pk", args{"account_pk", "fake8470d33c59a5cbf5e10df426eb97c2773ab890c3364f4162ba782a56ca998", 0, 10, nil}, 200},
+		{"invalid by", args{"invalidby", "fake8470d33c59a5cbf5e10df426eb97c2773ab890c3364f4162ba782a56ca998", 0, 10, nil}, 400},
 	}
 
+	txType := 7
 	statusCode, txs := GetTxs(s, 0, 100)
 	if statusCode == http.StatusOK && len(txs.Txs) > 0 {
 		_, account := GetAccount(s, "name", txs.Txs[len(txs.Txs)-1].AccountName)
 		tests = append(tests, []testcase{
-			{"found by index", args{"account_index", strconv.Itoa(int(account.Index)), 0, 10}, 200},
-			{"found by name", args{"account_name", account.Name, 0, 10}, 200},
-			{"found by pk", args{"account_pk", account.Pk, 0, 10}, 200},
+			{"found by index", args{"account_index", strconv.Itoa(int(account.Index)), 0, 10, nil}, 200},
+			{"found by name", args{"account_name", account.Name, 0, 10, nil}, 200},
+			{"found by pk", args{"account_pk", account.Pk, 0, 10, nil}, 200},
+			{"found by index and type", args{"account_index", strconv.Itoa(int(account.Index)), 0, 10, &txType}, 200},
 		}...)
 	}
 
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
-			httpCode, result := GetAccountTxs(s, tt.args.by, tt.args.value, tt.args.offset, tt.args.limit)
+			httpCode, result := GetAccountTxs(s, tt.args.by, tt.args.value, tt.args.offset, tt.args.limit, tt.args.txType)
 			assert.Equal(t, tt.httpCode, httpCode)
 			if httpCode == http.StatusOK {
 				if tt.args.offset < int(result.Total) {
@@ -65,8 +68,12 @@ func (s *ApiServerSuite) TestGetAccountTxs() {
 
 }
 
-func GetAccountTxs(s *ApiServerSuite, by, value string, offset, limit int) (int, *types.Txs) {
-	resp, err := http.Get(fmt.Sprintf("%s/api/v1/accountTxs?by=%s&value=%s&offset=%d&limit=%d", s.url, by, value, offset, limit))
+func GetAccountTxs(s *ApiServerSuite, by, value string, offset, limit int, txType *int) (int, *types.Txs) {
+	url := fmt.Sprintf("%s/api/v1/accountTxs?by=%s&value=%s&offset=%d&limit=%d", s.url, by, value, offset, limit)
+	if txType != nil {
+		url += fmt.Sprintf("&type=%d", *txType)
+	}
+	resp, err := http.Get(url)
 	assert.NoError(s.T(), err)
 	defer resp.Body.Close()
 

--- a/service/apiserver/test/getaccounttxs_test.go
+++ b/service/apiserver/test/getaccounttxs_test.go
@@ -19,7 +19,7 @@ func (s *ApiServerSuite) TestGetAccountTxs() {
 		value   string
 		offset  int
 		limit   int
-		txTypes []int
+		txTypes []int64
 	}
 
 	type testcase struct {
@@ -35,15 +35,15 @@ func (s *ApiServerSuite) TestGetAccountTxs() {
 		{"invalid by", args{"invalidby", "fake8470d33c59a5cbf5e10df426eb97c2773ab890c3364f4162ba782a56ca998", 0, 10, nil}, 400},
 	}
 
-	txType := 7
 	statusCode, txs := GetTxs(s, 0, 100)
 	if statusCode == http.StatusOK && len(txs.Txs) > 0 {
-		_, account := GetAccount(s, "name", txs.Txs[len(txs.Txs)-1].AccountName)
+		tx := txs.Txs[len(txs.Txs)-1]
+		_, account := GetAccount(s, "name", tx.AccountName)
 		tests = append(tests, []testcase{
 			{"found by index", args{"account_index", strconv.Itoa(int(account.Index)), 0, 10, nil}, 200},
 			{"found by name", args{"account_name", account.Name, 0, 10, nil}, 200},
 			{"found by pk", args{"account_pk", account.Pk, 0, 10, nil}, 200},
-			{"found by index and type", args{"account_index", strconv.Itoa(int(account.Index)), 0, 10, []int{txType}}, 200},
+			{"found by index and type", args{"account_index", strconv.Itoa(int(account.Index)), 0, 10, []int64{tx.Type}}, 200},
 		}...)
 	}
 
@@ -68,7 +68,7 @@ func (s *ApiServerSuite) TestGetAccountTxs() {
 
 }
 
-func GetAccountTxs(s *ApiServerSuite, by, value string, offset, limit int, txTypes []int) (int, *types.Txs) {
+func GetAccountTxs(s *ApiServerSuite, by, value string, offset, limit int, txTypes []int64) (int, *types.Txs) {
 	url := fmt.Sprintf("%s/api/v1/accountTxs?by=%s&value=%s&offset=%d&limit=%d", s.url, by, value, offset, limit)
 	for _, t := range txTypes {
 		url += fmt.Sprintf("&types[]=%d", t)

--- a/service/apiserver/test/getaccounttxs_test.go
+++ b/service/apiserver/test/getaccounttxs_test.go
@@ -44,6 +44,7 @@ func (s *ApiServerSuite) TestGetAccountTxs() {
 			{"found by name", args{"account_name", account.Name, 0, 10, nil}, 200},
 			{"found by pk", args{"account_pk", account.Pk, 0, 10, nil}, 200},
 			{"found by index and type", args{"account_index", strconv.Itoa(int(account.Index)), 0, 10, []int64{tx.Type}}, 200},
+			{"not found by index and type", args{"account_index", strconv.Itoa(int(account.Index)), 0, 10, []int64{10000}}, 200},
 		}...)
 	}
 
@@ -70,8 +71,9 @@ func (s *ApiServerSuite) TestGetAccountTxs() {
 
 func GetAccountTxs(s *ApiServerSuite, by, value string, offset, limit int, txTypes []int64) (int, *types.Txs) {
 	url := fmt.Sprintf("%s/api/v1/accountTxs?by=%s&value=%s&offset=%d&limit=%d", s.url, by, value, offset, limit)
-	for _, t := range txTypes {
-		url += fmt.Sprintf("&types[]=%d", t)
+	if len(txTypes) > 0 {
+		data, _ := json.Marshal(txTypes)
+		url += fmt.Sprintf("&types=%s", string(data))
 	}
 	resp, err := http.Get(url)
 	assert.NoError(s.T(), err)


### PR DESCRIPTION
### Description

Use function arguments to support query account txs by tx type

### Rationale

zkwallet frontend need the API changes

### Example

Add `type[]` in query string and it's optional

```
GET /api/v1/accountTxs?by=account_index&value=1&offset=0&limit=10&types=[7,8]
```

Array usage ref: https://github.com/zeromicro/go-zero/issues/2334#issuecomment-1243860331

### Changes

N/A