### PR TITLE
committer: fix txDetails generation bug

### DIFF
--- a/core/executor/deposit_nft_executor.go
+++ b/core/executor/deposit_nft_executor.go
@@ -57,7 +57,7 @@ func (e *DepositNftExecutor) Prepare() error {
 
 	// Mark the tree states that would be affected in this executor.
 	e.MarkNftDirty(txInfo.NftIndex)
-	e.MarkAccountAssetsDirty(txInfo.AccountIndex, []int64{0}) // Prepare asset 0 for generate an empty tx detail.
+	e.MarkAccountAssetsDirty(txInfo.AccountIndex, []int64{types.EmptyAccountAssetId}) // Prepare asset 0 for generate an empty tx detail.
 	return e.BaseExecutor.Prepare()
 }
 
@@ -149,14 +149,14 @@ func (e *DepositNftExecutor) GenerateTxDetails() ([]*tx.TxDetail, error) {
 	// user info
 	accountOrder := int64(0)
 	order := int64(0)
-	baseBalance := depositAccount.AssetInfo[0]
+	baseBalance := depositAccount.AssetInfo[types.EmptyAccountAssetId]
 	deltaBalance := &types.AccountAsset{
-		AssetId:                  0,
+		AssetId:                  types.EmptyAccountAssetId,
 		Balance:                  big.NewInt(0),
 		OfferCanceledOrFinalized: big.NewInt(0),
 	}
 	txDetails = append(txDetails, &tx.TxDetail{
-		AssetId:         0,
+		AssetId:         types.EmptyAccountAssetId,
 		AssetType:       types.FungibleAssetType,
 		AccountIndex:    txInfo.AccountIndex,
 		AccountName:     depositAccount.AccountName,

--- a/core/executor/full_exit_nft_executor.go
+++ b/core/executor/full_exit_nft_executor.go
@@ -81,7 +81,7 @@ func (e *FullExitNftExecutor) Prepare() error {
 
 	// Mark the tree states that would be affected in this executor.
 	e.MarkNftDirty(txInfo.NftIndex)
-	e.MarkAccountAssetsDirty(txInfo.AccountIndex, []int64{0}) // Prepare asset 0 for generate an empty tx detail.
+	e.MarkAccountAssetsDirty(txInfo.AccountIndex, []int64{types.EmptyAccountAssetId}) // Prepare asset 0 for generate an empty tx detail.
 	err = e.BaseExecutor.Prepare()
 	if err != nil {
 		return err
@@ -193,14 +193,14 @@ func (e *FullExitNftExecutor) GenerateTxDetails() ([]*tx.TxDetail, error) {
 	// user info
 	accountOrder := int64(0)
 	order := int64(0)
-	baseBalance := exitAccount.AssetInfo[0]
+	baseBalance := exitAccount.AssetInfo[types.EmptyAccountAssetId]
 	emptyDelta := &types.AccountAsset{
-		AssetId:                  0,
+		AssetId:                  types.EmptyAccountAssetId,
 		Balance:                  big.NewInt(0),
 		OfferCanceledOrFinalized: big.NewInt(0),
 	}
 	txDetails = append(txDetails, &tx.TxDetail{
-		AssetId:         0,
+		AssetId:         types.EmptyAccountAssetId,
 		AssetType:       types.FungibleAssetType,
 		AccountIndex:    txInfo.AccountIndex,
 		AccountName:     exitAccount.AccountName,

--- a/core/executor/transfer_nft_executor.go
+++ b/core/executor/transfer_nft_executor.go
@@ -45,7 +45,8 @@ func (e *TransferNftExecutor) Prepare() error {
 	// Mark the tree states that would be affected in this executor.
 	e.MarkNftDirty(txInfo.NftIndex)
 	e.MarkAccountAssetsDirty(txInfo.FromAccountIndex, []int64{txInfo.GasFeeAssetId})
-	e.MarkAccountAssetsDirty(txInfo.ToAccountIndex, []int64{})
+	// For empty tx details generation
+	e.MarkAccountAssetsDirty(txInfo.ToAccountIndex, []int64{types.EmptyAccountAssetId})
 	e.MarkAccountAssetsDirty(txInfo.GasAccountIndex, []int64{txInfo.GasFeeAssetId})
 	return e.BaseExecutor.Prepare()
 }
@@ -198,13 +199,13 @@ func (e *TransferNftExecutor) GenerateTxDetails() ([]*tx.TxDetail, error) {
 	order++
 	accountOrder++
 	txDetails = append(txDetails, &tx.TxDetail{
-		AssetId:      txInfo.GasFeeAssetId,
+		AssetId:      types.EmptyAccountAssetId,
 		AssetType:    types.FungibleAssetType,
 		AccountIndex: txInfo.ToAccountIndex,
 		AccountName:  toAccount.AccountName,
-		Balance:      toAccount.AssetInfo[txInfo.GasFeeAssetId].String(),
+		Balance:      toAccount.AssetInfo[types.EmptyAccountAssetId].String(),
 		BalanceDelta: types.ConstructAccountAsset(
-			txInfo.GasFeeAssetId,
+			types.EmptyAccountAssetId,
 			types.ZeroBigInt,
 			types.ZeroBigInt,
 		).String(),

--- a/core/executor/withdraw_nft_executor.go
+++ b/core/executor/withdraw_nft_executor.go
@@ -50,7 +50,7 @@ func (e *WithdrawNftExecutor) Prepare() error {
 	e.MarkAccountAssetsDirty(txInfo.AccountIndex, []int64{txInfo.GasFeeAssetId})
 	e.MarkAccountAssetsDirty(txInfo.GasAccountIndex, []int64{txInfo.GasFeeAssetId})
 	if nftInfo.CreatorAccountIndex != types.NilAccountIndex {
-		e.MarkAccountAssetsDirty(nftInfo.CreatorAccountIndex, []int64{})
+		e.MarkAccountAssetsDirty(nftInfo.CreatorAccountIndex, []int64{types.EmptyAccountAssetId})
 	}
 	err = e.BaseExecutor.Prepare()
 	if err != nil {
@@ -264,13 +264,13 @@ func (e *WithdrawNftExecutor) GenerateTxDetails() ([]*tx.TxDetail, error) {
 	order++
 	accountOrder++
 	txDetails = append(txDetails, &tx.TxDetail{
-		AssetId:      txInfo.GasFeeAssetId,
+		AssetId:      types.EmptyAccountAssetId,
 		AssetType:    types.FungibleAssetType,
 		AccountIndex: txInfo.CreatorAccountIndex,
 		AccountName:  creatorAccount.AccountName,
-		Balance:      creatorAccount.AssetInfo[txInfo.GasFeeAssetId].String(),
+		Balance:      creatorAccount.AssetInfo[types.EmptyAccountAssetId].String(),
 		BalanceDelta: types.ConstructAccountAsset(
-			txInfo.GasFeeAssetId,
+			types.EmptyAccountAssetId,
 			types.ZeroBigInt,
 			types.ZeroBigInt,
 		).String(),

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,6 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwjwegp5jy4=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/zkbnb-crypto v0.0.6-0.20221013023250-9141d78f2797 h1:lyVHEim4xs47Ejs1OBs3yiqLwLhQRjagb+BnXzXXFBw=
-github.com/bnb-chain/zkbnb-crypto v0.0.6-0.20221013023250-9141d78f2797/go.mod h1:KQ8k/vh0iEnNQaznmeK6ecaxylDOMWQ5Sa1sid3IXEU=
 github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20221014031300-2d6cc7e0b904 h1:M4H+zooUNQmMhPULiJ+rEWqLE7DjvGVXj/+4c8O2AsI=
 github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20221014031300-2d6cc7e0b904/go.mod h1:TSIDCYcRZCCFnx/VOXFd9jb9EDnn4xRxfERK1zGwrrU=
 github.com/bnb-chain/zkbnb-eth-rpc v0.0.2 h1:1rMa8XpplDNZaxeM1ifXMjSSeH/ucJyLUjHHEw1z4AA=

--- a/types/system.go
+++ b/types/system.go
@@ -39,5 +39,6 @@ const (
 )
 
 var (
-	ZeroBigInt = big.NewInt(0)
+	ZeroBigInt          = big.NewInt(0)
+	EmptyAccountAssetId = int64(0)
 )


### PR DESCRIPTION
### Description

When tx needs generate empty account details, `Prepare` function doesn't mark the empty asset id dirty, thus the `balance` of txDetails would be "null" which cause `witness` panic.

### Rationale

### Example


### Changes

Notable changes:
* Mark empty account `types.EmptyAccountAssetId` as dirty