### PR TITLE
feat: Implement `GET /executedTxs` API

### DIFF
--- a/dao/tx/tx.go
+++ b/dao/tx/tx.go
@@ -41,7 +41,7 @@ const (
 type getTxOption struct {
 	Types       []int64
 	Statuses    []int64
-	Id          int64
+	FromHash    string
 	WithDeleted bool
 }
 
@@ -59,9 +59,9 @@ func GetTxWithStatuses(statuses []int64) GetTxOptionFunc {
 	}
 }
 
-func GetTxWithFromId(id int64) GetTxOptionFunc {
+func GetTxWithFromHash(hash string) GetTxOptionFunc {
 	return func(o *getTxOption) {
-		o.Id = id
+		o.FromHash = hash
 	}
 }
 

--- a/dao/tx/tx.go
+++ b/dao/tx/tx.go
@@ -59,7 +59,7 @@ func GetTxWithStatuses(statuses []int64) GetTxOptionFunc {
 	}
 }
 
-func GetTxWithStartId(id int64) GetTxOptionFunc {
+func GetTxWithFromId(id int64) GetTxOptionFunc {
 	return func(o *getTxOption) {
 		o.Id = id
 	}

--- a/dao/tx/tx.go
+++ b/dao/tx/tx.go
@@ -39,8 +39,10 @@ const (
 )
 
 type getTxOption struct {
-	Types    []int64
-	Statuses []int64
+	Types       []int64
+	Statuses    []int64
+	Id          int64
+	WithDeleted bool
 }
 
 type GetTxOptionFunc func(*getTxOption)
@@ -54,6 +56,18 @@ func GetTxWithTypes(txTypes []int64) GetTxOptionFunc {
 func GetTxWithStatuses(statuses []int64) GetTxOptionFunc {
 	return func(o *getTxOption) {
 		o.Statuses = statuses
+	}
+}
+
+func GetTxWithStartId(id int64) GetTxOptionFunc {
+	return func(o *getTxOption) {
+		o.Id = id
+	}
+}
+
+func GetTxWithDeleted() GetTxOptionFunc {
+	return func(o *getTxOption) {
+		o.WithDeleted = true
 	}
 }
 

--- a/dao/tx/tx_pool.go
+++ b/dao/tx/tx_pool.go
@@ -91,7 +91,7 @@ func (m *defaultTxPoolModel) GetTxs(limit int64, offset int64, options ...GetTxO
 	}
 	if len(opt.FromHash) > 0 {
 		subTx = subTx.Select("id").Where("tx_hash = ?", opt.FromHash).Limit(1)
-		dbTx = dbTx.Where("id > ?", subTx)
+		dbTx = dbTx.Where("id > (?)", subTx)
 	}
 
 	dbTx = dbTx.Limit(int(limit)).Offset(int(offset)).Order("created_at desc, id desc").Find(&txs)
@@ -127,7 +127,7 @@ func (m *defaultTxPoolModel) GetTxsTotalCount(options ...GetTxOptionFunc) (count
 	}
 	if len(opt.FromHash) > 0 {
 		subTx = subTx.Select("id").Where("tx_hash = ?", opt.FromHash).Limit(1)
-		dbTx = dbTx.Where("id > ?", subTx)
+		dbTx = dbTx.Where("id > (?)", subTx)
 	}
 
 	dbTx = dbTx.Where("deleted_at is NULL").Count(&count)

--- a/dao/tx/tx_pool.go
+++ b/dao/tx/tx_pool.go
@@ -80,8 +80,15 @@ func (m *defaultTxPoolModel) GetTxs(limit int64, offset int64, options ...GetTxO
 	}
 
 	dbTx := m.DB.Table(m.table)
+
+	if opt.WithDeleted {
+		dbTx = dbTx.Unscoped()
+	}
 	if len(opt.Statuses) > 0 {
 		dbTx = dbTx.Where("tx_status IN ?", opt.Statuses)
+	}
+	if opt.Id > 0 {
+		dbTx = dbTx.Where("id >= ?", opt.Id)
 	}
 
 	dbTx = dbTx.Limit(int(limit)).Offset(int(offset)).Order("created_at desc, id desc").Find(&txs)

--- a/dao/tx/tx_pool.go
+++ b/dao/tx/tx_pool.go
@@ -31,8 +31,8 @@ type (
 	TxPoolModel interface {
 		CreatePoolTxTable() error
 		DropPoolTxTable() error
-		GetTxs(limit int64, offset int64) (txs []*Tx, err error)
-		GetTxsTotalCount() (count int64, err error)
+		GetTxs(limit int64, offset int64, options ...GetTxOptionFunc) (txs []*Tx, err error)
+		GetTxsTotalCount(options ...GetTxOptionFunc) (count int64, err error)
 		GetTxByTxHash(hash string) (txs *Tx, err error)
 		GetTxsByStatus(status int) (txs []*Tx, err error)
 		CreateTxs(txs []*Tx) error
@@ -73,8 +73,18 @@ func (m *defaultTxPoolModel) DropPoolTxTable() error {
 	return m.DB.Migrator().DropTable(m.table)
 }
 
-func (m *defaultTxPoolModel) GetTxs(limit int64, offset int64) (txs []*Tx, err error) {
-	dbTx := m.DB.Table(m.table).Where("tx_status = ?", StatusPending).Limit(int(limit)).Offset(int(offset)).Order("created_at desc, id desc").Find(&txs)
+func (m *defaultTxPoolModel) GetTxs(limit int64, offset int64, options ...GetTxOptionFunc) (txs []*Tx, err error) {
+	opt := &getTxOption{}
+	for _, f := range options {
+		f(opt)
+	}
+
+	dbTx := m.DB.Table(m.table)
+	if len(opt.Statuses) > 0 {
+		dbTx = dbTx.Where("tx_status IN ?", opt.Statuses)
+	}
+
+	dbTx = dbTx.Limit(int(limit)).Offset(int(offset)).Order("created_at desc, id desc").Find(&txs)
 	if dbTx.Error != nil {
 		return nil, types.DbErrSqlOperation
 	}
@@ -89,8 +99,18 @@ func (m *defaultTxPoolModel) GetTxsByStatus(status int) (txs []*Tx, err error) {
 	return txs, nil
 }
 
-func (m *defaultTxPoolModel) GetTxsTotalCount() (count int64, err error) {
-	dbTx := m.DB.Table(m.table).Where("tx_status = ? and deleted_at is NULL", StatusPending).Count(&count)
+func (m *defaultTxPoolModel) GetTxsTotalCount(options ...GetTxOptionFunc) (count int64, err error) {
+	opt := &getTxOption{}
+	for _, f := range options {
+		f(opt)
+	}
+
+	dbTx := m.DB.Table(m.table)
+	if len(opt.Statuses) > 0 {
+		dbTx = dbTx.Where("tx_status IN ?", opt.Statuses)
+	}
+
+	dbTx = dbTx.Where("deleted_at is NULL").Count(&count)
 	if dbTx.Error != nil {
 		return 0, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -358,7 +358,7 @@ Get executed transactions
 | ---- | ---------- | ----------- | -------- | ---- |
 | offset | query | offset, min 0 and max 100000 | Yes | integer |
 | limit | query | limit, min 1 and max 100 | Yes | integer |
-| from_id | query | start from the id | No | integer |
+| from_hash | query | start from the hash tx | No | string |
 
 ##### Responses
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -344,6 +344,29 @@ Get pending transactions
 | ---- | ----------- | ------ |
 | 200 | A successful response. | [Txs](#txs) |
 
+### /api/v1/executedTxs
+
+#### GET
+
+##### Summary
+
+Get executed transactions
+
+##### Parameters
+
+| Name | Located in | Description | Required | Schema |
+| ---- | ---------- | ----------- | -------- | ---- |
+| offset | query | offset, min 0 and max 100000 | Yes | integer |
+| limit | query | limit, min 1 and max 100 | Yes | integer |
+| from_id | query | start from the id | No | integer |
+
+##### Responses
+
+| Code | Description | Schema |
+| ---- | ----------- | ------ |
+| 200 | A successful response. | [Txs](#txs) |
+
+
 ### /api/v1/nextNonce
 
 #### GET

--- a/service/apiserver/internal/handler/routes.go
+++ b/service/apiserver/internal/handler/routes.go
@@ -136,6 +136,11 @@ func RegisterHandlers(server *rest.Server, serverCtx *svc.ServiceContext) {
 			},
 			{
 				Method:  http.MethodGet,
+				Path:    "/api/v1/executedTxs",
+				Handler: transaction.GetExecutedTxsHandler(serverCtx),
+			},
+			{
+				Method:  http.MethodGet,
 				Path:    "/api/v1/accountPendingTxs",
 				Handler: transaction.GetAccountPendingTxsHandler(serverCtx),
 			},

--- a/service/apiserver/internal/handler/transaction/getexecutedtxshandler.go
+++ b/service/apiserver/internal/handler/transaction/getexecutedtxshandler.go
@@ -1,0 +1,28 @@
+package transaction
+
+import (
+	"net/http"
+
+	"github.com/bnb-chain/zkbnb/service/apiserver/internal/logic/transaction"
+	"github.com/bnb-chain/zkbnb/service/apiserver/internal/svc"
+	"github.com/bnb-chain/zkbnb/service/apiserver/internal/types"
+	"github.com/zeromicro/go-zero/rest/httpx"
+)
+
+func GetExecutedTxsHandler(svcCtx *svc.ServiceContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req types.ReqGetRange
+		if err := httpx.Parse(r, &req); err != nil {
+			httpx.Error(w, err)
+			return
+		}
+
+		l := transaction.NewGetExecutedTxsLogic(r.Context(), svcCtx)
+		resp, err := l.GetExecutedTxs(&req)
+		if err != nil {
+			httpx.Error(w, err)
+		} else {
+			httpx.OkJson(w, resp)
+		}
+	}
+}

--- a/service/apiserver/internal/handler/transaction/getexecutedtxshandler.go
+++ b/service/apiserver/internal/handler/transaction/getexecutedtxshandler.go
@@ -11,7 +11,7 @@ import (
 
 func GetExecutedTxsHandler(svcCtx *svc.ServiceContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var req types.ReqGetRangeWithStartId
+		var req types.ReqGetRangeWithFromId
 		if err := httpx.Parse(r, &req); err != nil {
 			httpx.Error(w, err)
 			return

--- a/service/apiserver/internal/handler/transaction/getexecutedtxshandler.go
+++ b/service/apiserver/internal/handler/transaction/getexecutedtxshandler.go
@@ -11,7 +11,7 @@ import (
 
 func GetExecutedTxsHandler(svcCtx *svc.ServiceContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var req types.ReqGetRange
+		var req types.ReqGetRangeWithStartId
 		if err := httpx.Parse(r, &req); err != nil {
 			httpx.Error(w, err)
 			return

--- a/service/apiserver/internal/handler/transaction/getexecutedtxshandler.go
+++ b/service/apiserver/internal/handler/transaction/getexecutedtxshandler.go
@@ -11,7 +11,7 @@ import (
 
 func GetExecutedTxsHandler(svcCtx *svc.ServiceContext) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var req types.ReqGetRangeWithFromId
+		var req types.ReqGetRangeWithFromHash
 		if err := httpx.Parse(r, &req); err != nil {
 			httpx.Error(w, err)
 			return

--- a/service/apiserver/internal/logic/transaction/getexecutedtxslogic.go
+++ b/service/apiserver/internal/logic/transaction/getexecutedtxslogic.go
@@ -26,14 +26,14 @@ func NewGetExecutedTxsLogic(ctx context.Context, svcCtx *svc.ServiceContext) *Ge
 	}
 }
 
-func (l *GetExecutedTxsLogic) GetExecutedTxs(req *types.ReqGetRangeWithFromId) (*types.Txs, error) {
+func (l *GetExecutedTxsLogic) GetExecutedTxs(req *types.ReqGetRangeWithFromHash) (*types.Txs, error) {
 
 	options := []tx.GetTxOptionFunc{
 		tx.GetTxWithStatuses([]int64{tx.StatusExecuted}),
 		tx.GetTxWithDeleted(),
 	}
-	if req.FromId > 0 {
-		options = append(options, tx.GetTxWithFromId(req.FromId))
+	if len(req.FromHash) > 0 {
+		options = append(options, tx.GetTxWithFromHash(req.FromHash))
 	}
 
 	total, err := l.svcCtx.TxPoolModel.GetTxsTotalCount(options...)

--- a/service/apiserver/internal/logic/transaction/getexecutedtxslogic.go
+++ b/service/apiserver/internal/logic/transaction/getexecutedtxslogic.go
@@ -26,14 +26,14 @@ func NewGetExecutedTxsLogic(ctx context.Context, svcCtx *svc.ServiceContext) *Ge
 	}
 }
 
-func (l *GetExecutedTxsLogic) GetExecutedTxs(req *types.ReqGetRangeWithStartId) (*types.Txs, error) {
+func (l *GetExecutedTxsLogic) GetExecutedTxs(req *types.ReqGetRangeWithFromId) (*types.Txs, error) {
 
 	options := []tx.GetTxOptionFunc{
 		tx.GetTxWithStatuses([]int64{tx.StatusExecuted}),
 		tx.GetTxWithDeleted(),
 	}
-	if req.StartId > 0 {
-		options = append(options, tx.GetTxWithStartId(req.StartId))
+	if req.FromId > 0 {
+		options = append(options, tx.GetTxWithFromId(req.FromId))
 	}
 
 	total, err := l.svcCtx.TxPoolModel.GetTxsTotalCount(options...)

--- a/service/apiserver/internal/logic/transaction/getexecutedtxslogic.go
+++ b/service/apiserver/internal/logic/transaction/getexecutedtxslogic.go
@@ -3,32 +3,31 @@ package transaction
 import (
 	"context"
 
-	"github.com/zeromicro/go-zero/core/logx"
-
 	"github.com/bnb-chain/zkbnb/dao/tx"
 	"github.com/bnb-chain/zkbnb/service/apiserver/internal/logic/utils"
 	"github.com/bnb-chain/zkbnb/service/apiserver/internal/svc"
 	"github.com/bnb-chain/zkbnb/service/apiserver/internal/types"
 	types2 "github.com/bnb-chain/zkbnb/types"
+
+	"github.com/zeromicro/go-zero/core/logx"
 )
 
-type GetPendingTxsLogic struct {
+type GetExecutedTxsLogic struct {
 	logx.Logger
 	ctx    context.Context
 	svcCtx *svc.ServiceContext
 }
 
-func NewGetPendingTxsLogic(ctx context.Context, svcCtx *svc.ServiceContext) *GetPendingTxsLogic {
-	return &GetPendingTxsLogic{
+func NewGetExecutedTxsLogic(ctx context.Context, svcCtx *svc.ServiceContext) *GetExecutedTxsLogic {
+	return &GetExecutedTxsLogic{
 		Logger: logx.WithContext(ctx),
 		ctx:    ctx,
 		svcCtx: svcCtx,
 	}
 }
 
-func (l *GetPendingTxsLogic) GetPendingTxs(req *types.ReqGetRange) (*types.Txs, error) {
-
-	txStatuses := []int64{tx.StatusPending}
+func (l *GetExecutedTxsLogic) GetExecutedTxs(req *types.ReqGetRange) (*types.Txs, error) {
+	txStatuses := []int64{tx.StatusExecuted}
 
 	total, err := l.svcCtx.TxPoolModel.GetTxsTotalCount(tx.GetTxWithStatuses(txStatuses))
 	if err != nil {

--- a/service/apiserver/internal/logic/utils/converter.go
+++ b/service/apiserver/internal/logic/utils/converter.go
@@ -35,6 +35,7 @@ func ConvertTx(tx *tx.Tx) *types.Tx {
 	}
 
 	return &types.Tx{
+		Id:             int64(tx.ID),
 		Hash:           tx.TxHash,
 		Type:           tx.TxType,
 		GasFee:         tx.GasFee,

--- a/service/apiserver/internal/logic/utils/converter.go
+++ b/service/apiserver/internal/logic/utils/converter.go
@@ -35,7 +35,6 @@ func ConvertTx(tx *tx.Tx) *types.Tx {
 	}
 
 	return &types.Tx{
-		Id:             int64(tx.ID),
 		Hash:           tx.TxHash,
 		Type:           tx.TxType,
 		GasFee:         tx.GasFee,

--- a/service/apiserver/server.api
+++ b/service/apiserver/server.api
@@ -368,7 +368,7 @@ service server-api {
 	@handler GetPendingTxs
 	get /api/v1/pendingTxs (ReqGetRange) returns (Txs)
 	
-	@doc "Get executed transactions which are not packed into blocks"
+	@doc "Get executed transactions which previously added to tx pool"
 	@handler GetExecutedTxs
 	get /api/v1/executedTxs (ReqGetRangeWithFromId) returns (Txs)
 	

--- a/service/apiserver/server.api
+++ b/service/apiserver/server.api
@@ -262,6 +262,7 @@ service server-api {
 
 type (
 	Tx {
+		Id             int64  `json:"id"`
 		Hash           string `json:"hash"`
 		Type           int64  `json:"type,range=[1:64]"`
 		Amount         string `json:"amount"`

--- a/service/apiserver/server.api
+++ b/service/apiserver/server.api
@@ -30,6 +30,12 @@ type ReqGetRange {
 	Limit  uint32 `form:"limit,range=[1:100]"`
 }
 
+type ReqGetRangeWithStartId {
+	Offset  uint32 `form:"offset,range=[0:100000]"`
+	Limit   uint32 `form:"limit,range=[1:100]"`
+	StartId int64  `form:"start_id"`
+}
+
 /* ========================= Account =========================*/
 
 type (
@@ -364,7 +370,7 @@ service server-api {
 	
 	@doc "Get executed transactions which are not packed into blocks"
 	@handler GetExecutedTxs
-	get /api/v1/executedTxs (ReqGetRange) returns (Txs)
+	get /api/v1/executedTxs (ReqGetRangeWithStartId) returns (Txs)
 	
 	@doc "Get pending transactions of a specific account"
 	@handler GetAccountPendingTxs

--- a/service/apiserver/server.api
+++ b/service/apiserver/server.api
@@ -30,10 +30,10 @@ type ReqGetRange {
 	Limit  uint32 `form:"limit,range=[1:100]"`
 }
 
-type ReqGetRangeWithFromId {
-	Offset uint32 `form:"offset,range=[0:100000]"`
-	Limit  uint32 `form:"limit,range=[1:100]"`
-	FromId int64  `form:"from_id,optional"`
+type ReqGetRangeWithFromHash {
+	Offset   uint32 `form:"offset,range=[0:100000]"`
+	Limit    uint32 `form:"limit,range=[1:100]"`
+	FromHash string `form:"from_hash,optional"`
 }
 
 /* ========================= Account =========================*/
@@ -371,7 +371,7 @@ service server-api {
 	
 	@doc "Get executed transactions which previously added to tx pool"
 	@handler GetExecutedTxs
-	get /api/v1/executedTxs (ReqGetRangeWithFromId) returns (Txs)
+	get /api/v1/executedTxs (ReqGetRangeWithFromHash) returns (Txs)
 	
 	@doc "Get pending transactions of a specific account"
 	@handler GetAccountPendingTxs

--- a/service/apiserver/server.api
+++ b/service/apiserver/server.api
@@ -342,7 +342,7 @@ type (
 )
 
 service server-api {
-	@doc "Get transactions"
+	@doc "Get transactions which are already packed into blocks"
 	@handler GetTxs
 	get /api/v1/txs (ReqGetRange) returns (Txs)
 	
@@ -361,6 +361,10 @@ service server-api {
 	@doc "Get pending transactions"
 	@handler GetPendingTxs
 	get /api/v1/pendingTxs (ReqGetRange) returns (Txs)
+	
+	@doc "Get executed transactions which are not packed into blocks"
+	@handler GetExecutedTxs
+	get /api/v1/executedTxs (ReqGetRange) returns (Txs)
 	
 	@doc "Get pending transactions of a specific account"
 	@handler GetAccountPendingTxs

--- a/service/apiserver/server.api
+++ b/service/apiserver/server.api
@@ -30,10 +30,10 @@ type ReqGetRange {
 	Limit  uint32 `form:"limit,range=[1:100]"`
 }
 
-type ReqGetRangeWithStartId {
-	Offset  uint32 `form:"offset,range=[0:100000]"`
-	Limit   uint32 `form:"limit,range=[1:100]"`
-	StartId int64  `form:"start_id"`
+type ReqGetRangeWithFromId {
+	Offset uint32 `form:"offset,range=[0:100000]"`
+	Limit  uint32 `form:"limit,range=[1:100]"`
+	FromId int64  `form:"from_id,optional"`
 }
 
 /* ========================= Account =========================*/
@@ -370,7 +370,7 @@ service server-api {
 	
 	@doc "Get executed transactions which are not packed into blocks"
 	@handler GetExecutedTxs
-	get /api/v1/executedTxs (ReqGetRangeWithStartId) returns (Txs)
+	get /api/v1/executedTxs (ReqGetRangeWithFromId) returns (Txs)
 	
 	@doc "Get pending transactions of a specific account"
 	@handler GetAccountPendingTxs

--- a/service/apiserver/server.api
+++ b/service/apiserver/server.api
@@ -262,7 +262,6 @@ service server-api {
 
 type (
 	Tx {
-		Id             int64  `json:"id"`
 		Hash           string `json:"hash"`
 		Type           int64  `json:"type,range=[1:64]"`
 		Amount         string `json:"amount"`

--- a/service/apiserver/test/getexecutedtxs_test.go
+++ b/service/apiserver/test/getexecutedtxs_test.go
@@ -15,22 +15,22 @@ import (
 func (s *ApiServerSuite) TestGetExecutedTxs() {
 
 	type args struct {
-		offset int
-		limit  int
-		fromId int
+		offset   int
+		limit    int
+		fromHash string
 	}
 	tests := []struct {
 		name     string
 		args     args
 		httpCode int
 	}{
-		{"found", args{0, 10, 1}, 200},
-		{"found", args{0, 10, 0}, 200},
+		{"found", args{0, 10, "hash"}, 200},
+		{"found", args{0, 10, ""}, 200},
 	}
 
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
-			httpCode, result := GetExecutedTxs(s, tt.args.offset, tt.args.limit, tt.args.fromId)
+			httpCode, result := GetExecutedTxs(s, tt.args.offset, tt.args.limit, tt.args.fromHash)
 			assert.Equal(t, tt.httpCode, httpCode)
 			if httpCode == http.StatusOK {
 				if tt.args.offset < int(result.Total) {
@@ -49,10 +49,10 @@ func (s *ApiServerSuite) TestGetExecutedTxs() {
 
 }
 
-func GetExecutedTxs(s *ApiServerSuite, offset, limit, from_id int) (int, *types.Txs) {
+func GetExecutedTxs(s *ApiServerSuite, offset, limit int, from_hash string) (int, *types.Txs) {
 	url := fmt.Sprintf("%s/api/v1/executedTxs?offset=%d&limit=%d", s.url, offset, limit)
-	if from_id > 0 {
-		url += fmt.Sprintf("&from_id=%d", from_id)
+	if len(from_hash) > 0 {
+		url += fmt.Sprintf("&from_hash=%s", from_hash)
 	}
 	resp, err := http.Get(url)
 	assert.NoError(s.T(), err)

--- a/service/apiserver/test/getexecutedtxs_test.go
+++ b/service/apiserver/test/getexecutedtxs_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/bnb-chain/zkbnb/service/apiserver/internal/types"
 )
 
-func (s *ApiServerSuite) TestGetPendingTxs() {
+func (s *ApiServerSuite) TestGetExecutedTxs() {
 
 	type args struct {
 		offset int
@@ -28,7 +28,7 @@ func (s *ApiServerSuite) TestGetPendingTxs() {
 
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
-			httpCode, result := GetPendingTxs(s, tt.args.offset, tt.args.limit)
+			httpCode, result := GetExecutedTxs(s, tt.args.offset, tt.args.limit)
 			assert.Equal(t, tt.httpCode, httpCode)
 			if httpCode == http.StatusOK {
 				if tt.args.offset < int(result.Total) {
@@ -47,8 +47,8 @@ func (s *ApiServerSuite) TestGetPendingTxs() {
 
 }
 
-func GetPendingTxs(s *ApiServerSuite, offset, limit int) (int, *types.Txs) {
-	resp, err := http.Get(fmt.Sprintf("%s/api/v1/pendingTxs?offset=%d&limit=%d", s.url, offset, limit))
+func GetExecutedTxs(s *ApiServerSuite, offset, limit int) (int, *types.Txs) {
+	resp, err := http.Get(fmt.Sprintf("%s/api/v1/executedTxs?offset=%d&limit=%d", s.url, offset, limit))
 	assert.NoError(s.T(), err)
 	defer resp.Body.Close()
 

--- a/service/apiserver/test/getexecutedtxs_test.go
+++ b/service/apiserver/test/getexecutedtxs_test.go
@@ -15,20 +15,21 @@ import (
 func (s *ApiServerSuite) TestGetExecutedTxs() {
 
 	type args struct {
-		offset int
-		limit  int
+		offset  int
+		limit   int
+		startId int
 	}
 	tests := []struct {
 		name     string
 		args     args
 		httpCode int
 	}{
-		{"found", args{0, 10}, 200},
+		{"found", args{0, 10, 1}, 200},
 	}
 
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
-			httpCode, result := GetExecutedTxs(s, tt.args.offset, tt.args.limit)
+			httpCode, result := GetExecutedTxs(s, tt.args.offset, tt.args.limit, tt.args.startId)
 			assert.Equal(t, tt.httpCode, httpCode)
 			if httpCode == http.StatusOK {
 				if tt.args.offset < int(result.Total) {
@@ -47,8 +48,8 @@ func (s *ApiServerSuite) TestGetExecutedTxs() {
 
 }
 
-func GetExecutedTxs(s *ApiServerSuite, offset, limit int) (int, *types.Txs) {
-	resp, err := http.Get(fmt.Sprintf("%s/api/v1/executedTxs?offset=%d&limit=%d", s.url, offset, limit))
+func GetExecutedTxs(s *ApiServerSuite, offset, limit, startId int) (int, *types.Txs) {
+	resp, err := http.Get(fmt.Sprintf("%s/api/v1/executedTxs?offset=%d&limit=%d&start_id=%d", s.url, offset, limit, startId))
 	assert.NoError(s.T(), err)
 	defer resp.Body.Close()
 

--- a/service/apiserver/test/getexecutedtxs_test.go
+++ b/service/apiserver/test/getexecutedtxs_test.go
@@ -25,7 +25,7 @@ func (s *ApiServerSuite) TestGetExecutedTxs() {
 		httpCode int
 	}{
 		{"found", args{0, 10, "hash"}, 200},
-		{"found", args{0, 10, ""}, 200},
+		{"found without hash", args{0, 10, ""}, 200},
 	}
 
 	for _, tt := range tests {

--- a/service/apiserver/test/getexecutedtxs_test.go
+++ b/service/apiserver/test/getexecutedtxs_test.go
@@ -15,9 +15,9 @@ import (
 func (s *ApiServerSuite) TestGetExecutedTxs() {
 
 	type args struct {
-		offset  int
-		limit   int
-		startId int
+		offset int
+		limit  int
+		fromId int
 	}
 	tests := []struct {
 		name     string
@@ -25,11 +25,12 @@ func (s *ApiServerSuite) TestGetExecutedTxs() {
 		httpCode int
 	}{
 		{"found", args{0, 10, 1}, 200},
+		{"found", args{0, 10, 0}, 200},
 	}
 
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
-			httpCode, result := GetExecutedTxs(s, tt.args.offset, tt.args.limit, tt.args.startId)
+			httpCode, result := GetExecutedTxs(s, tt.args.offset, tt.args.limit, tt.args.fromId)
 			assert.Equal(t, tt.httpCode, httpCode)
 			if httpCode == http.StatusOK {
 				if tt.args.offset < int(result.Total) {
@@ -48,8 +49,12 @@ func (s *ApiServerSuite) TestGetExecutedTxs() {
 
 }
 
-func GetExecutedTxs(s *ApiServerSuite, offset, limit, startId int) (int, *types.Txs) {
-	resp, err := http.Get(fmt.Sprintf("%s/api/v1/executedTxs?offset=%d&limit=%d&start_id=%d", s.url, offset, limit, startId))
+func GetExecutedTxs(s *ApiServerSuite, offset, limit, from_id int) (int, *types.Txs) {
+	url := fmt.Sprintf("%s/api/v1/executedTxs?offset=%d&limit=%d", s.url, offset, limit)
+	if from_id > 0 {
+		url += fmt.Sprintf("&from_id=%d", from_id)
+	}
+	resp, err := http.Get(url)
 	assert.NoError(s.T(), err)
 	defer resp.Body.Close()
 


### PR DESCRIPTION
### Description

Create `GET /executedTxs API`

### Rationale

The difflayer of marketplace need the API to fetch transactions more earlier
For `GET /pendingTxs`, we can't get the executed result
For `GET /txs`, we can't get transactions that are not packed into blocks

### Example

`GET /executedTxs?offset=0&limit=10&from_hash=xxx`

Response
```
{
  "total": 10
  "txs": [
    ......,
  ]
}
```

### Changes

Notable changes:
* Add `GET /executedTxs` API
