### PR TITLE
fix: correct the wrong query of GetTxsTotalCount

### DIFF
--- a/dao/tx/tx_pool.go
+++ b/dao/tx/tx_pool.go
@@ -130,7 +130,7 @@ func (m *defaultTxPoolModel) GetTxsTotalCount(options ...GetTxOptionFunc) (count
 		dbTx = dbTx.Where("id > (?)", subTx)
 	}
 
-	dbTx = dbTx.Where("deleted_at is NULL").Count(&count)
+	dbTx = dbTx.Count(&count)
 	if dbTx.Error != nil {
 		return 0, types.DbErrSqlOperation
 	} else if dbTx.RowsAffected == 0 {


### PR DESCRIPTION

### Description

Remove the deleted_at condition check, GORM default behavior already applies the check and can use `Unscoped` to include deleted records

### Rationale

It always exclude deleted records which is wrong

### Example

N/A

### Changes

N/A