### PR TITLE
escape url

### DIFF
--- a/deploy-local.sh
+++ b/deploy-local.sh
@@ -63,9 +63,9 @@ echo 'latest block number = ' $blockNumber
 echo '4-2. deploy contracts, register and deposit on BSC Testnet'
 cd ${DEPLOY_PATH}
 cd ./zkbnb-contract
-cp -r ./.env.example ./.env
-sed -i -e "s/BSC_TESTNET_RPC=.*/BSC_TESTNET_RPC=${BSC_TESTNET_RPC}/" .env
-sed -i -e "s/BSC_TESTNET_PRIVATE_KEY=.*/BSC_TESTNET_PRIVATE_KEY=${BSC_TESTNET_PRIVATE_KEY}/" .env
+cp -r .env.example .env
+sed -i e "s~BSC_TESTNET_RPC=.*~BSC_TESTNET_RPC=${BSC_TESTNET_RPC}~" .env
+sed -i e "s/BSC_TESTNET_PRIVATE_KEY=.*/BSC_TESTNET_PRIVATE_KEY=${BSC_TESTNET_PRIVATE_KEY}/" .env
 yarn install
 npx hardhat --network BSCTestnet run ./scripts/deploy-keccak256/deploy.js
 echo 'Recorded latest contract addresses into ${DEPLOY_PATH}/zkbnb-contract/info/addresses.json'


### PR DESCRIPTION
### Description

Escape rpc url
### Rationale

The BSC_TESTNET_RPC variable does work well in different laptop due to sed version.


### Changes

Notable changes:
* Change `sed -i -e "s/BSC_TESTNET_RPC=.*/BSC_TESTNET_RPC=${BSC_TESTNET_RPC}/" .env` to `sed -i e "s~BSC_TESTNET_RPC=.*~BSC_TESTNET_RPC=${BSC_TESTNET_RPC}~" .env`