### PR TITLE
Change NetworkRPCSysConfigName to a configurable variable

### DIFF
--- a/deploy-local.sh
+++ b/deploy-local.sh
@@ -12,6 +12,7 @@ DEPLOY_PATH=~/zkbnb-deploy
 KEY_PATH=~/.zkbnb
 ZkBNB_REPO_PATH=$(cd `dirname $0`; pwd)
 CMC_TOKEN=cfce503f-fake-fake-fake-bbab5257dac8
+NETWORK_RPC_SYS_CONFIG_NAME=BscTestNetworkRpc # BscTestNetworkRpc or LocalTestNetworkRpc
 BSC_TESTNET_RPC=https://data-seed-prebsc-1-s1.binance.org:8545
 BSC_TESTNET_PRIVATE_KEY=acbaa26******************************a88367d9
 
@@ -172,7 +173,7 @@ CacheRedis:
     Type: node
 
 ChainConfig:
-  NetworkRPCSysConfigName: "BscTestNetworkRpc"
+  NetworkRPCSysConfigName: "${NETWORK_RPC_SYS_CONFIG_NAME}"
   #NetworkRPCSysConfigName: "LocalTestNetworkRpc"
   StartL1BlockHeight: $blockNumber
   ConfirmBlocksCount: 0
@@ -235,7 +236,7 @@ CacheRedis:
     Type: node
 
 ChainConfig:
-  NetworkRPCSysConfigName: "BscTestNetworkRpc"
+  NetworkRPCSysConfigName: "${NETWORK_RPC_SYS_CONFIG_NAME}"
   #NetworkRPCSysConfigName: "LocalTestNetworkRpc"
   ConfirmBlocksCount: 0
   MaxWaitingTime: 120


### PR DESCRIPTION
### Description
  Change `NetworkRPCSysConfigName` to a configurable variable
### Rationale
The default configuration uses the testnet, but you can configure it to use your local fast network
### Example
#### use local network:
```
NETWORK_RPC_SYS_CONFIG_NAME=LocalTestNetworkRpc
BSC_TESTNET_RPC=http://127.0.0.1:8545
BSC_TESTNET_PRIVATE_KEY=acbaa26******************************a88367d9
```

#### use testnet:
```
NETWORK_RPC_SYS_CONFIG_NAME=BscTestNetworkRpc
BSC_TESTNET_RPC=https://data-seed-prebsc-1-s1.binance.org:8545
BSC_TESTNET_PRIVATE_KEY=acbaa26******************************a88367d9
```

### Changes

Notable changes:
* add a variable `NETWORK_RPC_SYS_CONFIG_NAME` to set the value of `NetworkRPCSysConfigName`