### PR TITLE
Fix MaxPendingTxCount bug

### DIFF
--- a/service/apiserver/internal/logic/transaction/sendtxlogic.go
+++ b/service/apiserver/internal/logic/transaction/sendtxlogic.go
@@ -27,7 +27,8 @@ func NewSendTxLogic(ctx context.Context, svcCtx *svc.ServiceContext) *SendTxLogi
 }
 
 func (s *SendTxLogic) SendTx(req *types.ReqSendTx) (resp *types.TxHash, err error) {
-	pendingTxCount, err := s.svcCtx.TxPoolModel.GetTxsTotalCount()
+	txStatuses := []int64{tx.StatusPending}
+	pendingTxCount, err := s.svcCtx.TxPoolModel.GetTxsTotalCount(tx.GetTxWithStatuses(txStatuses))
 	if err != nil {
 		return nil, types2.AppErrInternal
 	}


### PR DESCRIPTION
### Description

MaxPendingTxCount will not work because of this segment:
```
	pendingTxCount, err := s.svcCtx.TxPoolModel.GetTxsTotalCount()
	if err != nil {
		return nil, types2.AppErrInternal
	}

	if s.svcCtx.Config.TxPool.MaxPendingTxCount > 0 && pendingTxCount >= int64(s.svcCtx.Config.TxPool.MaxPendingTxCount) {
		return nil, types2.AppErrTooManyTxs
	}
```

### Rationale

should get count of `pool tx` in StatusPending

### Example


### Changes
get count of `pool tx` in StatusPending

Notable changes:
