### PR TITLE
Add pprof profile to generate graph for performance analysis

### DIFF
--- a/common/metrics/pprof/pprof.go
+++ b/common/metrics/pprof/pprof.go
@@ -15,6 +15,7 @@ func NewPProfServer(srv *metrics.RunOnceHttpMux, addr string) metrics.MetricsSer
 	srv.Handle("/debug/pprof/allocs", pprof.Handler("allocs"))
 	srv.Handle("/debug/pprof/block", pprof.Handler("block"))
 	srv.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
+	srv.HandleFunc("/debug/pprof/profile", pprof.Profile)
 	return &PProfServer{
 		srv:  srv,
 		addr: addr,


### PR DESCRIPTION
### Description

Add pprof profile to generate graph for performance analysis

### Rationale

pprof profile
### Example
we can look at a 30-second CPU profile:
`go tool pprof http://localhost:6060/debug/pprof/profile?seconds=30`


### Changes

