### PR TITLE
Support running on a new local node

### DIFF
--- a/service/monitor/config/config.go
+++ b/service/monitor/config/config.go
@@ -19,7 +19,7 @@ type Config struct {
 }
 
 func (c Config) Validate() {
-	if c.ChainConfig.StartL1BlockHeight <= 0 || c.ChainConfig.MaxHandledBlocksCount <= 0 || c.ChainConfig.KeptHistoryBlocksCount <= 0 {
+	if c.ChainConfig.StartL1BlockHeight < 0 || c.ChainConfig.MaxHandledBlocksCount <= 0 || c.ChainConfig.KeptHistoryBlocksCount <= 0 {
 		panic("invalid chain config")
 	}
 }


### PR DESCRIPTION
### Description

Supports running on a new node which block number is from 0
### Rationale

If you run the project using a new node for testing, it will throw an error
```
504|monitor  | panic: invalid chain config
504|monitor  | goroutine 1 [running]:
504|monitor  | github.com/bnb-chain/zkbnb/service/monitor/config.Config.Validate(...)
504|monitor  | 	/Users/user/zkbnb-deploy/zkbnb/service/monitor/config/config.go:23
504|monitor  | github.com/bnb-chain/zkbnb/service/monitor.Run({0x7ff7bfeff1c2, 0x3c})
504|monitor  | 	/Users/user/zkbnb-deploy/zkbnb/service/monitor/monitor.go:20 +0x567
504|monitor  | main.main.func4(0xc0000a9560)
504|monitor  | 	/Users/user/zkbnb-deploy/zkbnb/cmd/zkbnb/main.go:109 +0x57
504|monitor  | github.com/urfave/cli/v2.(*Command).Run(0xc0000a9560, 0xc0003d3e00)
504|monitor  | 	/Users/user/go/pkg/mod/github.com/urfave/cli/v2@v2.11.2/command.go:173 +0x738
504|monitor  | github.com/urfave/cli/v2.(*App).RunContext(0xc0007268c0, {0x5363888, 0xc000134008}, {0xc000138000, 0xe, 0xe})
504|monitor  | 	/Users/user/go/pkg/mod/github.com/urfave/cli/v2@v2.11.2/app.go:382 +0xe0c
504|monitor  | github.com/urfave/cli/v2.(*App).Run(...)
504|monitor  | 	/Users/user/go/pkg/mod/github.com/urfave/cli/v2@v2.11.2/app.go:251
504|monitor  | main.main()
504|monitor  | 	/Users/user/zkbnb-deploy/zkbnb/cmd/zkbnb/main.go:249 +0x1086
504|monitor  | exit status 2
PM2          | App [monitor:504] exited with code [1] via signal [SIGINT]
PM2          | App [monitor:504] starting in -fork mode-
PM2          | App [monitor:504] online
```
fixed this by this pr


### Changes

Notable changes:
* `StartL1BlockHeight` can be 0