### PR TITLE
Add param skipSigChk to skip signature check in committer

### DIFF
--- a/core/block_processor.go
+++ b/core/block_processor.go
@@ -47,7 +47,7 @@ func (p *CommitProcessor) Process(tx *tx.Tx) error {
 		return err
 	}
 	start = time.Now()
-	err = executor.VerifyInputs(true)
+	err = executor.VerifyInputs(true, true)
 	p.metrics.TxVerifyInputsMetrics.Set(float64(time.Since(start).Milliseconds()))
 	if err != nil {
 		return err
@@ -104,7 +104,7 @@ func (p *APIProcessor) Process(tx *tx.Tx) error {
 		logx.Error("fail to prepare:", err)
 		return mappingPrepareErrors(err)
 	}
-	err = executor.VerifyInputs(false)
+	err = executor.VerifyInputs(false, false)
 	if err != nil {
 		return mappingVerifyInputsErrors(err)
 	}

--- a/core/executor/atomic_match_executor.go
+++ b/core/executor/atomic_match_executor.go
@@ -68,11 +68,11 @@ func (e *AtomicMatchExecutor) Prepare() error {
 	return e.BaseExecutor.Prepare()
 }
 
-func (e *AtomicMatchExecutor) VerifyInputs(skipGasAmtChk bool) error {
+func (e *AtomicMatchExecutor) VerifyInputs(skipGasAmtChk, skipSigChk bool) error {
 	bc := e.bc
 	txInfo := e.txInfo
 
-	err := e.BaseExecutor.VerifyInputs(skipGasAmtChk)
+	err := e.BaseExecutor.VerifyInputs(skipGasAmtChk, skipSigChk)
 	if err != nil {
 		return err
 	}

--- a/core/executor/cancel_offer_executor.go
+++ b/core/executor/cancel_offer_executor.go
@@ -44,10 +44,10 @@ func (e *CancelOfferExecutor) Prepare() error {
 	return e.BaseExecutor.Prepare()
 }
 
-func (e *CancelOfferExecutor) VerifyInputs(skipGasAmtChk bool) error {
+func (e *CancelOfferExecutor) VerifyInputs(skipGasAmtChk, skipSigChk bool) error {
 	txInfo := e.txInfo
 
-	err := e.BaseExecutor.VerifyInputs(skipGasAmtChk)
+	err := e.BaseExecutor.VerifyInputs(skipGasAmtChk, skipSigChk)
 	if err != nil {
 		return err
 	}

--- a/core/executor/create_collection_executor.go
+++ b/core/executor/create_collection_executor.go
@@ -54,10 +54,10 @@ func (e *CreateCollectionExecutor) Prepare() error {
 	return nil
 }
 
-func (e *CreateCollectionExecutor) VerifyInputs(skipGasAmtChk bool) error {
+func (e *CreateCollectionExecutor) VerifyInputs(skipGasAmtChk, skipSigChk bool) error {
 	txInfo := e.txInfo
 
-	err := e.BaseExecutor.VerifyInputs(skipGasAmtChk)
+	err := e.BaseExecutor.VerifyInputs(skipGasAmtChk, skipSigChk)
 	if err != nil {
 		return err
 	}

--- a/core/executor/deposit_executor.go
+++ b/core/executor/deposit_executor.go
@@ -54,7 +54,7 @@ func (e *DepositExecutor) Prepare() error {
 	return e.BaseExecutor.Prepare()
 }
 
-func (e *DepositExecutor) VerifyInputs(skipGasAmtChk bool) error {
+func (e *DepositExecutor) VerifyInputs(skipGasAmtChk, skipSigChk bool) error {
 	txInfo := e.txInfo
 
 	if txInfo.AssetAmount.Cmp(types.ZeroBigInt) < 0 {

--- a/core/executor/deposit_nft_executor.go
+++ b/core/executor/deposit_nft_executor.go
@@ -61,7 +61,7 @@ func (e *DepositNftExecutor) Prepare() error {
 	return e.BaseExecutor.Prepare()
 }
 
-func (e *DepositNftExecutor) VerifyInputs(skipGasAmtChk bool) error {
+func (e *DepositNftExecutor) VerifyInputs(skipGasAmtChk, skipSigChk bool) error {
 	bc := e.bc
 	txInfo := e.txInfo
 

--- a/core/executor/executor.go
+++ b/core/executor/executor.go
@@ -21,7 +21,7 @@ type IBlockchain interface {
 
 type TxExecutor interface {
 	Prepare() error
-	VerifyInputs(skipGasAmtChk bool) error
+	VerifyInputs(skipGasAmtChk, skipSigChk bool) error
 	ApplyTransaction() error
 	GeneratePubData() error
 	GetExecutedTx() (*tx.Tx, error)

--- a/core/executor/full_exit_executor.go
+++ b/core/executor/full_exit_executor.go
@@ -65,7 +65,7 @@ func (e *FullExitExecutor) Prepare() error {
 	return nil
 }
 
-func (e *FullExitExecutor) VerifyInputs(skipGasAmtChk bool) error {
+func (e *FullExitExecutor) VerifyInputs(skipGasAmtChk, skipSigChk bool) error {
 	return nil
 }
 

--- a/core/executor/full_exit_nft_executor.go
+++ b/core/executor/full_exit_nft_executor.go
@@ -106,7 +106,7 @@ func (e *FullExitNftExecutor) Prepare() error {
 	return nil
 }
 
-func (e *FullExitNftExecutor) VerifyInputs(skipGasAmtChk bool) error {
+func (e *FullExitNftExecutor) VerifyInputs(skipGasAmtChk, skipSigChk bool) error {
 	return nil
 }
 

--- a/core/executor/mint_nft_executor.go
+++ b/core/executor/mint_nft_executor.go
@@ -50,10 +50,10 @@ func (e *MintNftExecutor) Prepare() error {
 	return e.BaseExecutor.Prepare()
 }
 
-func (e *MintNftExecutor) VerifyInputs(skipGasAmtChk bool) error {
+func (e *MintNftExecutor) VerifyInputs(skipGasAmtChk, skipSigChk bool) error {
 	txInfo := e.txInfo
 
-	err := e.BaseExecutor.VerifyInputs(skipGasAmtChk)
+	err := e.BaseExecutor.VerifyInputs(skipGasAmtChk, skipSigChk)
 	if err != nil {
 		return err
 	}

--- a/core/executor/register_zns_executor.go
+++ b/core/executor/register_zns_executor.go
@@ -47,7 +47,7 @@ func (e *RegisterZnsExecutor) Prepare() error {
 	return nil
 }
 
-func (e *RegisterZnsExecutor) VerifyInputs(skipGasAmtChk bool) error {
+func (e *RegisterZnsExecutor) VerifyInputs(skipGasAmtChk, skipSigChk bool) error {
 	bc := e.bc
 	txInfo := e.txInfo
 

--- a/core/executor/transfer_executor.go
+++ b/core/executor/transfer_executor.go
@@ -43,11 +43,11 @@ func (e *TransferExecutor) Prepare() error {
 	return e.BaseExecutor.Prepare()
 }
 
-func (e *TransferExecutor) VerifyInputs(skipGasAmtChk bool) error {
+func (e *TransferExecutor) VerifyInputs(skipGasAmtChk, skipSigChk bool) error {
 	bc := e.bc
 	txInfo := e.txInfo
 
-	err := e.BaseExecutor.VerifyInputs(skipGasAmtChk)
+	err := e.BaseExecutor.VerifyInputs(skipGasAmtChk, skipSigChk)
 	if err != nil {
 		return err
 	}

--- a/core/executor/transfer_nft_executor.go
+++ b/core/executor/transfer_nft_executor.go
@@ -51,10 +51,10 @@ func (e *TransferNftExecutor) Prepare() error {
 	return e.BaseExecutor.Prepare()
 }
 
-func (e *TransferNftExecutor) VerifyInputs(skipGasAmtChk bool) error {
+func (e *TransferNftExecutor) VerifyInputs(skipGasAmtChk, skipSigChk bool) error {
 	txInfo := e.txInfo
 
-	err := e.BaseExecutor.VerifyInputs(skipGasAmtChk)
+	err := e.BaseExecutor.VerifyInputs(skipGasAmtChk, skipSigChk)
 	if err != nil {
 		return err
 	}

--- a/core/executor/withdraw_executor.go
+++ b/core/executor/withdraw_executor.go
@@ -42,10 +42,10 @@ func (e *WithdrawExecutor) Prepare() error {
 	return e.BaseExecutor.Prepare()
 }
 
-func (e *WithdrawExecutor) VerifyInputs(skipGasAmtChk bool) error {
+func (e *WithdrawExecutor) VerifyInputs(skipGasAmtChk, skipSigChk bool) error {
 	txInfo := e.txInfo
 
-	err := e.BaseExecutor.VerifyInputs(skipGasAmtChk)
+	err := e.BaseExecutor.VerifyInputs(skipGasAmtChk, skipSigChk)
 	if err != nil {
 		return err
 	}

--- a/core/executor/withdraw_nft_executor.go
+++ b/core/executor/withdraw_nft_executor.go
@@ -73,10 +73,10 @@ func (e *WithdrawNftExecutor) Prepare() error {
 	return nil
 }
 
-func (e *WithdrawNftExecutor) VerifyInputs(skipGasAmtChk bool) error {
+func (e *WithdrawNftExecutor) VerifyInputs(skipGasAmtChk, skipSigChk bool) error {
 	txInfo := e.txInfo
 
-	err := e.BaseExecutor.VerifyInputs(skipGasAmtChk)
+	err := e.BaseExecutor.VerifyInputs(skipGasAmtChk, skipSigChk)
 	if err != nil {
 		return err
 	}

--- a/tree/util.go
+++ b/tree/util.go
@@ -76,7 +76,7 @@ func CommitTrees(
 	nftTree bsmt.SparseMerkleTree) error {
 	start := time.Now()
 	assetTreeChanges := assetTrees.GetChanges()
-	logx.Infof("GetChanges=%d", float64(time.Since(start).Milliseconds()))
+	logx.Infof("GetChanges=%v", time.Since(start))
 
 	defer assetTrees.CleanChanges()
 	totalTask := len(assetTreeChanges) + 2


### PR DESCRIPTION
### Description

Skip VerifySignature in committer

### Rationale

apiserver already done the verify job, verify in committer could be removed.
### Example

### Changes
interface `TxExecutor` and its implementations.