### PR TITLE
feat: adapt optimized gnark version

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -51,12 +51,14 @@ jobs:
       - name: run integration test
         if: ${{ !contains(github.event.pull_request.body, '/skip-integration-test') }}
         run: |
+          source <(sudo cat /server/.env)
           export PATH=$PATH:/usr/local/go/bin:/usr/local/go/bin:/root/go/bin
           export ZkBNB=$(sudo cat ~/zkbnb/deployment/dependency/zkbnb-contract/info/addresses.json  | jq -r '.zkbnbProxy')
           export AssetGov=$(sudo cat ~/zkbnb/deployment/dependency/zkbnb-contract/info/addresses.json  | jq -r '.assetGovernance')
           export TestLogLevel=2
           export L1EndPoint=$L1_ENDPOINT
           export L2EndPoint=$L2_ENDPOINT
+          export GovKey=${BSC_TESTNET_PRIVATE_KEY}
           
           cd /tmp && sudo rm -rf ./zkbnb-integration-test
           git clone --branch main https://github.com/bnb-chain/zkbnb-integration-test.git

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -42,7 +42,7 @@ jobs:
           blockNr=$(sudo bash ./deployment/tool/tool.sh blockHeight)
           sudo BSC_TESTNET_PRIVATE_KEY=${BSC_TESTNET_PRIVATE_KEY} bash ./deployment/tool/tool.sh all
           sudo bash ./deployment/docker-compose/docker-compose.sh down
-          sudo bash ./deployment/docker-compose/docker-compose.sh up $blockNr
+          sudo SK=${BSC_TESTNET_PRIVATE_KEY} bash ./deployment/docker-compose/docker-compose.sh up $blockNr
           echo "Contract addresses"
           cat ~/zkbnb/deployment/dependency/zkbnb-contract/info/addresses.json
           echo "Waiting 3m for the initialization tx to be verified"

--- a/common/prove/proof_keys.go
+++ b/common/prove/proof_keys.go
@@ -16,22 +16,14 @@ import (
 	"github.com/bnb-chain/zkbnb-crypto/circuit/types"
 )
 
-func LoadProvingKey(filepath string) (pk groth16.ProvingKey, err error) {
+func LoadProvingKey(filepath string) (pks []groth16.ProvingKey, err error) {
 	logx.Info("start reading proving key")
-	pk = groth16.NewProvingKey(ecc.BN254)
-	f, _ := os.Open(filepath)
-	_, err = pk.ReadFrom(f)
-	if err != nil {
-		return pk, fmt.Errorf("read file error")
-	}
-	f.Close()
-
-	return pk, nil
+	return groth16.ReadSegmentProveKey(filepath)
 }
 
 func LoadVerifyingKey(filepath string) (verifyingKey groth16.VerifyingKey, err error) {
 	verifyingKey = groth16.NewVerifyingKey(ecc.BN254)
-	f, _ := os.Open(filepath)
+	f, _ := os.Open(filepath + ".vk.save")
 	_, err = verifyingKey.ReadFrom(f)
 	if err != nil {
 		return verifyingKey, fmt.Errorf("read file error")
@@ -43,9 +35,10 @@ func LoadVerifyingKey(filepath string) (verifyingKey groth16.VerifyingKey, err e
 
 func GenerateProof(
 	r1cs frontend.CompiledConstraintSystem,
-	provingKey groth16.ProvingKey,
+	provingKey []groth16.ProvingKey,
 	verifyingKey groth16.VerifyingKey,
 	cBlock *circuit.Block,
+	session string,
 ) (proof groth16.Proof, err error) {
 	// verify CryptoBlock
 	blockWitness, err := circuit.SetBlockWitness(cBlock)
@@ -60,11 +53,17 @@ func GenerateProof(
 	if err != nil {
 		return proof, err
 	}
+
 	vWitness, err := frontend.NewWitness(&verifyWitness, ecc.BN254, frontend.PublicOnly())
 	if err != nil {
 		return proof, err
 	}
-	proof, err = groth16.Prove(r1cs, provingKey, witness, backend.WithHints(types.Keccak256))
+	// This is for test
+	//witnessFullBytes, _ := witness.MarshalJSON()
+	//err = os.WriteFile("witness_full.save", witnessFullBytes, 0666)
+	//witnessPubBytes, _ := vWitness.MarshalJSON()
+	//err = os.WriteFile("witness_pub.save", witnessPubBytes, 0666)
+	proof, err = groth16.ProveRoll(r1cs, provingKey[0], provingKey[1], witness, session, backend.WithHints(types.Keccak256))
 	if err != nil {
 		return proof, err
 	}

--- a/deploy-local.sh
+++ b/deploy-local.sh
@@ -114,9 +114,7 @@ CacheRedis:
   - Host: 127.0.0.1:6379
     Type: node
 
-KeyPath:
-  ProvingKeyPath: [${KEY_PATH}/zkbnb10.pk]
-  VerifyingKeyPath: [${KEY_PATH}/zkbnb10.vk]
+KeyPath: [${KEY_PATH}/zkbnb10]
 
 BlockConfig:
   OptionalBlockSizes: [10]

--- a/deploy-qa.sh
+++ b/deploy-qa.sh
@@ -100,10 +100,7 @@ CacheRedis:
   - Host: 127.0.0.1:6379
     Type: node
 
-KeyPath:
-  ProvingKeyPath: [/home/.zkbnb/zkbnb1.pk, /home/.zkbnb/zkbnb10.pk]
-  VerifyingKeyPath: [/home/.zkbnb/zkbnb1.vk, /home/.zkbnb/zkbnb10.vk]
-  KeyTxCounts:    [1, 10]
+KeyPath: [/home/.zkbnb/zkbnb1, /home/.zkbnb/zkbnb10]
 
 TreeDB:
   Driver: memorydb

--- a/deployment/docker-compose/docker-compose.sh
+++ b/deployment/docker-compose/docker-compose.sh
@@ -27,9 +27,7 @@ CacheRedis:
   - Host: redis:6379
     Type: node
 
-KeyPath:
-  ProvingKeyPath: [/server/.zkbnb/zkbnb1.pk]
-  VerifyingKeyPath: [/server/.zkbnb/zkbnb1.vk]
+KeyPath: [/server/.zkbnb]
 
 LogConf:
   ServiceName: prover

--- a/deployment/docker-compose/docker.env
+++ b/deployment/docker-compose/docker.env
@@ -7,6 +7,5 @@ REDIS_VERSION=latest
 DATABASE_USER=postgres
 DATABASE_PASS=ZkBNB@123
 DATABASE_NAME=zkbnb
-SK=acbaa269bd7573ff12361be4b97201aef019776ea13384681d4e5ba6a88367d9
 CMC_TOKEN=cfce503f-fake-fake-fake-bbab5257dac8
 CMC_URL=https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest?symbol=

--- a/deployment/helm/zkbnb/templates/configmap.yaml
+++ b/deployment/helm/zkbnb/templates/configmap.yaml
@@ -13,9 +13,7 @@ data:
     CacheRedis:
       {{- toYaml .Values.configs.redisCache | nindent 6 }}
 
-    KeyPath:
-      ProvingKeyPath: [/server/.zkbnb/zkbnb1.pk, /server/.zkbnb/zkbnb10.pk]
-      VerifyingKeyPath: [/server/.zkbnb/zkbnb1.vk, /server/.zkbnb/zkbnb10.vk]
+    KeyPath: [/server/.zkbnb/zkbnb1, /server/.zkbnb/zkbnb10]
 
     BlockConfig:
       OptionalBlockSizes: [1, 10]

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
-	github.com/fxamacker/cbor/v2 v2.2.0 // indirect
+	github.com/fxamacker/cbor/v2 v2.4.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
@@ -96,7 +96,7 @@ require (
 	github.com/consensys/gnark v0.7.0
 	github.com/consensys/gnark-crypto v0.7.0
 	github.com/eko/gocache/v2 v2.3.1
-	github.com/ethereum/go-ethereum v1.10.23
+	github.com/ethereum/go-ethereum v1.10.26
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/pkg/errors v0.9.1
@@ -114,6 +114,6 @@ require (
 )
 
 replace (
-	github.com/consensys/gnark => github.com/bnb-chain/gnark v0.7.1-0.20221031143243-a94d59b60efe
-	github.com/consensys/gnark-crypto => github.com/bnb-chain/gnark-crypto v0.7.1-0.20221101004736-92cbe59f55b4
+	github.com/consensys/gnark => github.com/bnb-chain/gnark v0.7.1-0.20221116101045-5d28e94a3e69
+	github.com/consensys/gnark-crypto => github.com/bnb-chain/gnark-crypto v0.7.1-0.20221116021202-8d6fc01ac262
 )

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,7 @@ github.com/ClickHouse/clickhouse-go/v2 v2.0.14/go.mod h1:iq2DUGgpA4BBki2CVwrF8x4
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/DmitriyVTitov/size v1.5.0/go.mod h1:le6rNI4CoLQV1b9gzp1+3d7hMAD/uu2QcJ+aYbNgiU0=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -117,10 +118,10 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwjwegp5jy4=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/gnark v0.7.1-0.20221031143243-a94d59b60efe h1:aAMpjWQOPesVwr+By0QzxQgy+bjUns4T9RO/QACrTis=
-github.com/bnb-chain/gnark v0.7.1-0.20221031143243-a94d59b60efe/go.mod h1:oQnMurInsfe+9rG4l8qh8AFVihfuRCS5H3XPJH/6HPM=
-github.com/bnb-chain/gnark-crypto v0.7.1-0.20221101004736-92cbe59f55b4 h1:Ti3fuo4/1BvdumJX0eCB7vLSjrxP8tl8e2mXdQoeFP8=
-github.com/bnb-chain/gnark-crypto v0.7.1-0.20221101004736-92cbe59f55b4/go.mod h1:KPSuJzyxkJA8xZ/+CV47tyqkr9MmpZA3PXivK4VPrVg=
+github.com/bnb-chain/gnark v0.7.1-0.20221116101045-5d28e94a3e69 h1:opczrQy0kE8rDlLjhj4b56k8t8GrHZ/eV1OjmQalh74=
+github.com/bnb-chain/gnark v0.7.1-0.20221116101045-5d28e94a3e69/go.mod h1:J5is/1NQUxPfIDDG/x/+TBX2c0byx48KiLRLCheby1A=
+github.com/bnb-chain/gnark-crypto v0.7.1-0.20221116021202-8d6fc01ac262 h1:kYHgB6keVdBf07XcCFnpvG6rNI40hUWL0Z1JStn62g4=
+github.com/bnb-chain/gnark-crypto v0.7.1-0.20221116021202-8d6fc01ac262/go.mod h1:KPSuJzyxkJA8xZ/+CV47tyqkr9MmpZA3PXivK4VPrVg=
 github.com/bnb-chain/zkbnb-crypto v0.0.6-0.20220928090246-9a20106a2347/go.mod h1:L1BEYSG945hwjJCtR5LUQ1pvRmydSsk9oU2d9YvoOrA=
 github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20221104095956-e2b2f4d4ae4e h1:uZC86BGCno2OcPL52nmo8BGaIV1MdfTxUlsIuDF6K2c=
 github.com/bnb-chain/zkbnb-crypto v0.0.8-0.20221104095956-e2b2f4d4ae4e/go.mod h1:AlzTbvhQojUFpArKHiGHkEYDnapebUbFC/+mek1pZvU=
@@ -236,8 +237,9 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ethereum/go-ethereum v1.10.17/go.mod h1:Lt5WzjM07XlXc95YzrhosmR4J9Ahd6X2wyEV2SvGhk0=
-github.com/ethereum/go-ethereum v1.10.23 h1:Xk8XAT4/UuqcjMLIMF+7imjkg32kfVFKoeyQDaO2yWM=
 github.com/ethereum/go-ethereum v1.10.23/go.mod h1:EYFyF19u3ezGLD4RqOkLq+ZCXzYbLoNDdZlMt7kyKFg=
+github.com/ethereum/go-ethereum v1.10.26 h1:i/7d9RBBwiXCEuyduBQzJw/mKmnvzsN14jqBmytw72s=
+github.com/ethereum/go-ethereum v1.10.26/go.mod h1:EYFyF19u3ezGLD4RqOkLq+ZCXzYbLoNDdZlMt7kyKFg=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -258,8 +260,9 @@ github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUork
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/fxamacker/cbor/v2 v2.2.0 h1:6eXqdDDe588rSYAi1HfZKbx6YYQO4mxQ9eC6xYpU/JQ=
 github.com/fxamacker/cbor/v2 v2.2.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
+github.com/fxamacker/cbor/v2 v2.4.0 h1:ri0ArlOR+5XunOP8CRUowT0pSJOwhW098ZCUyskZD88=
+github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61/go.mod h1:Q0X6pkwTILDlzrGEckF6HKjXe48EgsY/l7K7vhY4MW8=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=

--- a/service/prover/config/config.go
+++ b/service/prover/config/config.go
@@ -9,12 +9,9 @@ type Config struct {
 	Postgres struct {
 		DataSource string
 	}
-	CacheRedis cache.CacheConf
-	LogConf    logx.LogConf
-	KeyPath    struct {
-		ProvingKeyPath   []string
-		VerifyingKeyPath []string
-	}
+	CacheRedis  cache.CacheConf
+	LogConf     logx.LogConf
+	KeyPath     []string
 	BlockConfig struct {
 		OptionalBlockSizes []int
 	}

--- a/service/prover/etc/config.yaml.example
+++ b/service/prover/etc/config.yaml.example
@@ -7,9 +7,7 @@ CacheRedis:
   - Host: redis:6379
     Type: node
 
-KeyPath:
-  ProvingKeyPath: [/app/zkbnb1.pk]
-  VerifyingKeyPath: [/app/zkbnb1.vk]
+KeyPath: [/app/zkbnb1]
 
 BlockConfig:
   OptionalBlockSizes: [1]


### PR DESCRIPTION
### Description

This pr modifies pk loading code according to the optimized pk format (https://github.com/bnb-chain/zkbnb-crypto/pull/67), loads r1cs from file instead of compile when prover service starts, and call `ProveRoll` to use the proof generation optimization

### Rationale

### Example

### Changes

Notable changes:
* load r1cs from file
* load pk according to the new format